### PR TITLE
Allow use of custom service annotations

### DIFF
--- a/charts/snyk-broker/templates/broker_service.yaml
+++ b/charts/snyk-broker/templates/broker_service.yaml
@@ -3,6 +3,10 @@ kind: Service
 metadata:
   name: "{{ .Values.scmType}}-broker-service"
   namespace: {{ .Release.Namespace }}
+  {{- with .Values.serviceAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "snyk-broker.labels" . | nindent 4 }}
 spec:

--- a/charts/snyk-broker/values.yaml
+++ b/charts/snyk-broker/values.yaml
@@ -249,6 +249,8 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name: "snyk-broker"
 
+serviceAnnotations: {}
+
 podAnnotations: {}
 
 podSecurityContext: {}


### PR DESCRIPTION
Our Kubernetes infrastructure only allows for private load balancers, so we needed to be able to add an annotation to the service object to make it private.

It was also useful for adding another annotation to the service which defined the external DNS name for the generated ELB.

```
    service:
      brokerType: LoadBalancer
    serviceAnnotations:
      service.beta.kubernetes.io/aws-load-balancer-internal: 'true'
      external-dns.alpha.kubernetes.io/hostname: snyk.example.com
```