### PR TITLE
added UPSTREAM_URL env var to snyk code agent deployment

### DIFF
--- a/charts/snyk-broker/templates/code_agent_deployment.yaml
+++ b/charts/snyk-broker/templates/code_agent_deployment.yaml
@@ -47,6 +47,8 @@ spec:
           env:
             - name: PORT
               value: {{ .Values.deployment.container.caSnykPort | squote }}
+            - name: UPSTREAM_URL
+              value: "https://deeproxy.snyk.io"
             - name: SNYK_TOKEN
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
Added the UPSTREAM_URL env var to the code agent as described during discussion with our Snyk support team.