### PR TITLE
feat: Adding support for imagePullSecrets

### DIFF
--- a/charts/snyk-broker/Chart.yaml
+++ b/charts/snyk-broker/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: snyk-broker
-version: 1.1.12
+version: 1.2.0
 description: A Helm chart for Kubernetes
 type: application

--- a/charts/snyk-broker/templates/broker_deployment.yaml
+++ b/charts/snyk-broker/templates/broker_deployment.yaml
@@ -21,6 +21,10 @@ spec:
       labels:
         {{- include "snyk-broker.selectorLabels" . | nindent 8 }}
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       serviceAccountName: {{ include "snyk-broker.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}

--- a/charts/snyk-broker/templates/code_agent_deployment.yaml
+++ b/charts/snyk-broker/templates/code_agent_deployment.yaml
@@ -25,6 +25,10 @@ spec:
         app.kubernetes.io/name: {{ .Release.Name }}-ca
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       serviceAccountName: {{ include "snyk-broker.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}

--- a/charts/snyk-broker/templates/cra_deployment.yaml
+++ b/charts/snyk-broker/templates/cra_deployment.yaml
@@ -25,6 +25,10 @@ spec:
         app.kubernetes.io/name: {{ .Release.Name }}-cr
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       serviceAccountName: {{ include "snyk-broker.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}

--- a/charts/snyk-broker/values.yaml
+++ b/charts/snyk-broker/values.yaml
@@ -232,6 +232,11 @@ brokerReadinessProbe:
     failureThreshold: 3
 
 
+##### Broker Image Pull Secrets Parameters #####
+
+imagePullSecrets: []
+# - name: registrySecretName
+
 ##### Broker Resource Values #####
 brokerResources:
    limits:


### PR DESCRIPTION
The helm chart currently does not support imagePullSecrets which prevents us from pulling the images from our internal private registry.

This PR adds the missing functionality.

Let me know if you want me to bump the version in the Chart.yaml as part of this PR.