### PR TITLE
feat: Added ability to deploy a broker ingress

### DIFF
--- a/charts/snyk-broker/Chart.yaml
+++ b/charts/snyk-broker/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: snyk-broker
-version: 1.1.12
+version: 1.2.0
 description: A Helm chart for Kubernetes
 type: application

--- a/charts/snyk-broker/templates/_helpers.tpl
+++ b/charts/snyk-broker/templates/_helpers.tpl
@@ -67,3 +67,35 @@ Content of accept.json configuration file (either provided as literal value)
 {{- define "snyk-broker.acceptJson" -}}
 {{- with .Values.acceptJson}}{{.}}{{end}}
 {{- end}}
+
+{{/*
+Return the appropriate apiVersion for ingress.
+*/}}
+{{- define "snyk-broker.ingress.apiVersion" -}}
+  {{- if and (.Capabilities.APIVersions.Has "networking.k8s.io/v1") (semverCompare ">= 1.19-0" .Capabilities.KubeVersion.Version) -}}
+      {{- print "networking.k8s.io/v1" -}}
+  {{- else if .Capabilities.APIVersions.Has "networking.k8s.io/v1beta1" -}}
+    {{- print "networking.k8s.io/v1beta1" -}}
+  {{- else -}}
+    {{- print "extensions/v1beta1" -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
+Return if ingress is stable.
+*/}}
+{{- define "snyk-broker.ingress.isStable" -}}
+  {{- eq (include "snyk-broker.ingress.apiVersion" .) "networking.k8s.io/v1" -}}
+{{- end -}}
+{{/*
+Return if ingress supports ingressClassName.
+*/}}
+{{- define "snyk-broker.ingress.supportsIngressClassName" -}}
+  {{- or (eq (include "snyk-broker.ingress.isStable" .) "true") (and (eq (include "snyk-broker.ingress.apiVersion" .) "networking.k8s.io/v1beta1") (semverCompare ">= 1.18-0" .Capabilities.KubeVersion.Version)) -}}
+{{- end -}}
+{{/*
+Return if ingress supports pathType.
+*/}}
+{{- define "snyk-broker.ingress.supportsPathType" -}}
+  {{- or (eq (include "snyk-broker.ingress.isStable" .) "true") (and (eq (include "snyk-broker.ingress.apiVersion" .) "networking.k8s.io/v1beta1") (semverCompare ">= 1.18-0" .Capabilities.KubeVersion.Version)) -}}
+{{- end -}}

--- a/charts/snyk-broker/templates/broker_ingress.yaml
+++ b/charts/snyk-broker/templates/broker_ingress.yaml
@@ -1,0 +1,79 @@
+{{- if .Values.brokerIngress.enabled -}}
+{{- $ingressApiIsStable := eq (include "snyk-broker.ingress.isStable" .) "true" -}}
+{{- $ingressSupportsIngressClassName := eq (include "snyk-broker.ingress.supportsIngressClassName" .) "true" -}}
+{{- $ingressSupportsPathType := eq (include "snyk-broker.ingress.supportsPathType" .) "true" -}}
+{{- $fullName := include "snyk-broker.fullname" . -}}
+{{- $scmType := .Values.scmType -}}
+{{- $servicePort := .Values.service.port -}}
+{{- $ingressPath := .Values.brokerIngress.path -}}
+{{- $ingressPathType := .Values.brokerIngress.pathType -}}
+{{- $extraPaths := .Values.brokerIngress.extraPaths -}}
+apiVersion: {{ include "snyk-broker.ingress.apiVersion" . }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "snyk-broker.labels" . | nindent 4 }}
+    {{- with .Values.brokerIngress.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- if .Values.brokerIngress.annotations }}
+  annotations:
+    {{- range $key, $value := .Values.brokerIngress.annotations }}
+    {{ $key }}: {{ tpl $value $ | quote }}
+    {{- end }}
+  {{- end }}
+spec:
+  {{- if and $ingressSupportsIngressClassName .Values.brokerIngress.ingressClassName }}
+  ingressClassName: {{ .Values.brokerIngress.ingressClassName }}
+  {{- end -}}
+{{- if .Values.brokerIngress.tls }}
+  tls:
+{{ tpl (toYaml .Values.brokerIngress.tls) $ | indent 4 }}
+{{- end }}
+  rules:
+  {{- if .Values.brokerIngress.hosts  }}
+  {{- range .Values.brokerIngress.hosts }}
+    - host: {{ tpl . $}}
+      http:
+        paths:
+{{- if $extraPaths }}
+{{ toYaml $extraPaths | indent 10 }}
+{{- end }}
+          - path: {{ $ingressPath }}
+            {{- if $ingressSupportsPathType }}
+            pathType: {{ $ingressPathType }}
+            {{- end }}
+            backend:
+              {{- if $ingressApiIsStable }}
+              service:
+                name: {{ $scmType }}-broker-service
+                port:
+                  number: {{ $servicePort }}
+              {{- else }}
+              serviceName: {{ $scmType }}-broker-service
+              servicePort: {{ $servicePort }}
+              {{- end }}
+  {{- end }}
+  {{- else }}
+    - http:
+        paths:
+          - backend:
+              {{- if $ingressApiIsStable }}
+              service:
+                name: {{ $scmType }}-broker-service
+                port:
+                  number: {{ $servicePort }}
+              {{- else }}
+              serviceName: {{ $scmType }}-broker-service
+              servicePort: {{ $servicePort }}
+              {{- end }}
+            {{- if $ingressPath }}
+            path: {{ $ingressPath }}
+            {{- end }}
+            {{- if $ingressSupportsPathType }}
+            pathType: {{ $ingressPathType }}
+            {{- end }}
+  {{- end -}}
+{{- end }}

--- a/charts/snyk-broker/values.yaml
+++ b/charts/snyk-broker/values.yaml
@@ -341,6 +341,41 @@ service:
   #      - chart-example.local
 
 
+##### Optionally Deploy a Broker Ingress Resource #####
+brokerIngress:
+  enabled: true
+  # For Kubernetes >= 1.18 you should specify the ingress-controller via the field ingressClassName
+  # See https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/#specifying-the-class-of-an-ingress
+  ingressClassName: ""
+  annotations: {}
+    #kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  labels: {}
+  path: /
+  pathType: Prefix
+  hosts:
+    - chart-example.local
+  ## Extra paths to prepend to every host configuration. This is useful when working with annotation based services.
+  extraPaths: []
+  # - path: /*
+  #   backend:
+  #     serviceName: ssl-redirect
+  #     servicePort: use-annotation
+  ## Or for k8s > 1.19
+  # - path: /*
+  #   pathType: Prefix
+  #   backend:
+  #     service:
+  #       name: ssl-redirect
+  #       port:
+  #         name: use-annotation
+
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+
 ##### Do not adjust these settings. The Broker is not deigned to work with multiple replicas
 
 autoscaling:


### PR DESCRIPTION
The chart currently only supports ingress traffic to the broker via a LoadBalancer service type. This PR adds functionality to deploy an ingress record giving the user another option.