### PR TITLE
Fix typo in README for Container Registry Agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ helm install snyk-broker-chart . \
              --set scmType=container-registry-agent \
              --set brokerClientUrl=http://container-registry-agent-broker-service:8000 \
              --set brokerToken=<ENTER_BROKER_TOKEN> \
-             --set crType=<ENTER_CR_TYPE>\
+             --set crType=<ENTER_CR_TYPE> \
              --set crBase=<ENTER_CR_BASE_URL> \
              --set crUsername=<ENTER_CR_URSERNAME> \
              --set crPassword=<ENTER_CR_PASSWORD> \


### PR DESCRIPTION
Added a space between URL and trailing slash for brokerClientURL in CRA docs