### PR TITLE
Ability to toggle service account usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,13 @@ To use an existing service account, add the following parameters to the install 
 --set serviceAccount.name=<ENTER_EXISTING_SERVICE_ACCOUNT> \
 ```
 
+If you do not - or can not, due to permissions, etc - use service accounts, add the following parameters to the install command:
+
+```
+--set serviceAccount.enabled=false \
+--set serviceAccount.create=false \
+```
+
 ## Deploying Multiple Brokers In The Same Namespace
 
 To deploy an additional broker into the same namespace as an existing broker, see the following example.
@@ -347,6 +354,8 @@ To use this chart behind a proxy, set the ```httpProxy``` and ```httpsProxy``` v
 | `logEnableBody`                       | Enable Log Body                                                             | `false`                                                                       |
 | `image.repository`                    | Broker Image                                                                | `snyk/broker`                                                                 |
 | `deployment.container.containerPort`  | Container Port (Back End)                                                   | `8000`                                                                        |
+| `serviceAccount.enabled`              | Whether to use service accounts in deployment templates                     | `true`                                                                        |
+| `serviceAccount.create`               | Whether Helm should create a new service account                            | `true`                                                                        |
 | `serviceAccount.name`                 | Name of service account to be created                                       | `snyk-broker`                                                                 |
 | `service.port`                        | Front End Port for broker client                                            | `8000`                                                                        |
 | `crImage`                             | Image Tag                                                                   | `latest`                                                                      |

--- a/charts/snyk-broker/templates/broker_deployment.yaml
+++ b/charts/snyk-broker/templates/broker_deployment.yaml
@@ -21,7 +21,9 @@ spec:
       labels:
         {{- include "snyk-broker.selectorLabels" . | nindent 8 }}
     spec:
+      {{- if .Values.serviceAccount.enabled }}
       serviceAccountName: {{ include "snyk-broker.serviceAccountName" . }}
+      {{- end }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/charts/snyk-broker/templates/code_agent_deployment.yaml
+++ b/charts/snyk-broker/templates/code_agent_deployment.yaml
@@ -25,7 +25,9 @@ spec:
         app.kubernetes.io/name: {{ .Release.Name }}-ca
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
+      {{- if .Values.serviceAccount.enabled }}
       serviceAccountName: {{ include "snyk-broker.serviceAccountName" . }}
+      {{- end }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/charts/snyk-broker/templates/cra_deployment.yaml
+++ b/charts/snyk-broker/templates/cra_deployment.yaml
@@ -25,7 +25,9 @@ spec:
         app.kubernetes.io/name: {{ .Release.Name }}-cr
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
+      {{- if .Values.serviceAccount.enabled }}
       serviceAccountName: {{ include "snyk-broker.serviceAccountName" . }}
+      {{- end }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/charts/snyk-broker/values.yaml
+++ b/charts/snyk-broker/values.yaml
@@ -241,7 +241,11 @@ fullnameOverride: ""
 ##### Service Account Values. Nothing to change here #####
 
 serviceAccount:
-  # Specifies whether a service account should be created
+  # Specifies whether to use a service account or not
+  enabled: true
+  # Specifies whether a service account should be created. 
+  # Note: Ensure you specify an existing service account in the name value
+  # if enabled == true AND create == false.
   create: true
   # Annotations to add to the service account
   annotations: {}


### PR DESCRIPTION
Resolves #14 

Adds new value: `serviceAccount.enabled`.

Verified behavior is unchanged if:
1. `serviceAccount.enabled` = true
2. `serviceAccount.enabled` is unspecified or commented out

Only if `serviceAccount.enabled` is explicitly set to false does it remove `spec.template.spec.serviceAccountName`

While I manually verified across the charts locally, here are some rudimentary proof points setting:

1. Nothing - using default values
2. Setting `serviceAccount.enabled` to false
3. Setting Setting `serviceAccount.enabled` to true

```
 ✘ me@laptop  ~/Projects/personal/snyk-broker-helm   feature/service-account-enabled-toggle ● 
helm template snyk-broker charts/snyk-broker/. \ 
--set scmType=github-com \ 
--set brokerToken=my-broker-token \ 
--set scmToken=my-scm-token  \ 
--set brokerClientUrl=https://snyk-broker.example.com/broker | grep serviceAccountName
      serviceAccountName: snyk-broker
 me@laptop  ~/Projects/personal/snyk-broker-helm   feature/service-account-enabled-toggle ●  helm template snyk-broker charts/snyk-broker/. \ 
--set scmType=github-com \ 
--set brokerToken=my-broker-token \ 
--set scmToken=my-scm-token  \ 
--set brokerClientUrl=https://snyk-broker.example.com/broker \ 
--set serviceAccount.enabled=false | grep serviceAccountName
 ✘ me@laptop  ~/Projects/personal/snyk-broker-helm   feature/service-account-enabled-toggle ●  helm template snyk-broker charts/snyk-broker/. \ 
--set scmType=github-com \ 
--set brokerToken=my-broker-token \ 
--set scmToken=my-scm-token  \ 
--set brokerClientUrl=https://snyk-broker.example.com/broker \ 
--set serviceAccount.enabled=true \ 
--set serviceAccount.create=true | grep serviceAccountName
      serviceAccountName: snyk-broker
```
