### PR TITLE
docs: fix broken link for code agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ helm install snyk-broker-chart . \
 ```github-cr```<br>
 
 ## Snyk Code Agent
-To deploy the Snyk Code Agent, you must set the ```enableCodeAgent``` flag to ```true```. See more information about the [Snyk Code Agent](https://support.snyk.io/hc/en-us/articles/4404137655569-Snyk-Code-local-git-support). Ensure you have the proper entries in the accept.json file. Grab the example file for the appropriate SCM [HERE](https://github.com/snyk/broker/tree/master/client-templates). Ensure you have the additional entries as specified by the Snyk Code Agent documentation.
+To deploy the Snyk Code Agent, you must set the ```enableCodeAgent``` flag to ```true```. See more information about the [Snyk Code Agent](https://docs.snyk.io/features/snyk-broker/snyk-broker-code-agent). Ensure you have the proper entries in the accept.json file. Grab the example file for the appropriate SCM [HERE](https://github.com/snyk/broker/tree/master/client-templates). Ensure you have the additional entries as specified by the Snyk Code Agent documentation.
 
 Here is an example command for GitLab:
 


### PR DESCRIPTION
This PR fixes broken documentation link to Snyk Broker Code Agent.