### PR TITLE
add broker liveness and readiness probe options

### DIFF
--- a/charts/snyk-broker/templates/broker_deployment.yaml
+++ b/charts/snyk-broker/templates/broker_deployment.yaml
@@ -40,6 +40,20 @@ spec:
           ports:
             - name: http
               containerPort: {{ .Values.deployment.container.containerPort }}
+          {{- if .Values.brokerLivenessProbe.enabled }}
+          livenessProbe:
+            httpGet:
+              port: {{ .Values.deployment.container.containerPort }}
+              path: {{ .Values.brokerLivenessProbe.path }}
+            {{- toYaml .Values.brokerLivenessProbe.config | nindent 12 }}
+          {{- end }}
+          {{- if .Values.brokerReadinessProbe.enabled }}
+          readinessProbe:
+            httpGet:
+              port: {{ .Values.deployment.container.containerPort }}
+              path: {{ .Values.brokerReadinessProbe.path }}
+            {{- toYaml .Values.brokerReadinessProbe.config | nindent 12 }}
+          {{- end }}
           volumeMounts:
               {{- if (include "snyk-broker.acceptJson" .)}}
               - name: {{ include "snyk-broker.fullname" . }}-accept-volume
@@ -64,6 +78,10 @@ spec:
           env:
             - name: BROKER_SERVER_URL
               value: {{ .Values.brokerServerUrl }}
+            - name: BROKER_HEALTHCHECK_PATH
+              value: {{ .Values.healthCheckPath }}
+            - name: BROKER_SYSTEMCHECK_PATH
+              value: {{ .Values.systemCheckPath }}
           {{- if eq .Values.scmType "github-com" }}
        # Github
             - name: BROKER_TOKEN

--- a/charts/snyk-broker/values.yaml
+++ b/charts/snyk-broker/values.yaml
@@ -18,6 +18,7 @@ brokerClientUrl: ""
 brokerServerUrl: "https://broker.snyk.io"
 
 
+
 ##### SCM Generic #####
 
 # scmType is used to define the Source Control that you are connecting to. 
@@ -196,6 +197,30 @@ image:
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
+
+# Health and System Check Paths for the broker
+healthCheckPath: &healthCheckPath "/healthcheck"
+systemCheckPath: &systemCheckPath "/systemcheck"
+
+# Configure K8s Liveness and Readiness Probes for broker
+brokerLivenessProbe:
+  enabled: true
+  path: *healthCheckPath
+  config:
+    initialDelaySeconds: 3
+    periodSeconds: 10
+    timeoutSeconds: 1
+    failureThreshold: 3  
+
+
+brokerReadinessProbe:
+  enabled: true
+  path: *systemCheckPath
+  config:
+    initialDelaySeconds: 3
+    periodSeconds: 10
+    timeoutSeconds: 1
+    failureThreshold: 3
 
 
 ##### Broker Resource Values #####


### PR DESCRIPTION
This address #16 and is a blocker for us deploying this chart internally.

This allows configuring and setting a liveness and readiness probe on the broker via Helm chart values. It also allows configuring the healthcheck and system check paths via environment variables. 

I decided to use `/systemcheck` as the readiness and `/healthcheck` as the liveness, but they are configurable in case in the future a combined endpoint is created (as discussed [here](https://github.com/snyk/broker/issues/371)

The new values.yaml options look like this:

```
# Health and System Check Paths for the broker
healthCheckPath: &healthCheckPath "/healthcheck"
systemCheckPath: &systemCheckPath "/systemcheck"

# Configure K8s Liveness and Readiness Probes for broker
brokerLivenessProbe:
  enabled: true
  path: *healthCheckPath
  config:
    initialDelaySeconds: 3
    periodSeconds: 10
    timeoutSeconds: 1
    failureThreshold: 3  


brokerReadinessProbe:
  enabled: true
  path: *systemCheckPath
  config:
    initialDelaySeconds: 3
    periodSeconds: 10
    timeoutSeconds: 1
    failureThreshold: 3
```

I'm open to refactoring or abstracting more, but this is a pattern I've seen used and think it's a good balance of sane defaults and configurability.

Let me know what you think and if we can merge this in so we can deploy this chart internally!