### PR TITLE
chore: bump helm action to 1.4.1

### DIFF
--- a/.github/workflows/helm-releaser.yaml
+++ b/.github/workflows/helm-releaser.yaml
@@ -20,6 +20,6 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.1.0
+        uses: helm/chart-releaser-action@v1.4.1
         env:
           CR_TOKEN: "${{ secrets.GH_TOKEN }}"


### PR DESCRIPTION
It was *very* out of date, and the upgrade should fix the 404 errors we see when trying to release.