### PR TITLE
feat: Allow setting image tag

### DIFF
--- a/charts/snyk-broker/templates/broker_deployment.yaml
+++ b/charts/snyk-broker/templates/broker_deployment.yaml
@@ -35,7 +35,11 @@ spec:
               memory: {{ .Values.brokerResources.requests.memory}}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.scmType}}"
+          {{- if .Values.image.tag }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}-{{ .Values.scmType }}"
+          {{- else }}
+          image: "{{ .Values.image.repository }}:{{ .Values.scmType }}"
+          {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http

--- a/charts/snyk-broker/values.yaml
+++ b/charts/snyk-broker/values.yaml
@@ -207,7 +207,7 @@ image:
   crRepository: snyk/container-registry-agent
   caRepository: snyk/code-agent
   pullPolicy: Always
-  # Overrides the image tag whose default is the chart appVersion.
+  # Overrides the image tag. If left empty the latest version is used
   tag: ""
 
 # Health and System Check Paths for the broker


### PR DESCRIPTION
# What this does
Currently the `image.tag` inside of `values.yaml` is not used. This PR adds the ability to specify a tag which will then be respected.
If left empty the behavior stays  the same (the latest image will be pulled). 

# How can it be tested
```
cd charts/sny-broker
helm template broker . -f values.yaml --output-dir tmp 
```

Empty tag
<img width="687" alt="Screenshot 2022-10-28 at 10 10 32" src="https://user-images.githubusercontent.com/26271333/198538177-a51829ad-203c-4a43-809d-228fa5068a84.png">

Tag populated with a value
<img width="687" alt="Screenshot 2022-10-28 at 10 11 10" src="https://user-images.githubusercontent.com/26271333/198538212-440ecf0d-9ad0-4c74-8d93-825face1fb7b.png">


fixes #18