### PR TITLE
updating readme to fix helm repo name

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This is a Helm Chart to deploy the [Snyk Broker](https://github.com/snyk/broker)
 To add this chart, you can add the repo:
 ```helm repo add snyk-broker https://snyk.github.io/snyk-broker-helm/```
 
-In which case instead of ```helm install snyk-broker-chart .``` you would instead use ```helm install snyk-broker-chart snyk-broker``` for all the commands below. 
+In which case instead of ```helm install snyk-broker-chart .``` you would instead use ```helm install snyk-broker-chart snyk-broker/snyk-broker``` for all the commands below. 
 
 Alternatively, clone this repository and navigate to the ```/charts/snyk-broker``` directory.
 


### PR DESCRIPTION
Changing the helm repo name in the readme to reflect the naming in the Helm repo.

![Screen Shot 2022-11-11 at 1 35 47 PM (1)](https://user-images.githubusercontent.com/8006059/201701217-a9a5971a-4995-41e0-ac65-ea4ddafc47c5.png)
