### PR TITLE
Allow to set user defined environment variables.

### DIFF
--- a/charts/snyk-broker/templates/broker_deployment.yaml
+++ b/charts/snyk-broker/templates/broker_deployment.yaml
@@ -313,6 +313,10 @@ spec:
             - name: ACCEPT
               value: /home/node/accept.json
          {{- end }}
+         # Additional Environment Variables
+         {{- if .Values.brokerAdditionalEnvironmentVariables  }}
+          {{- toYaml .Values.brokerAdditionalEnvironmentVariables | nindent 12 }}
+         {{- end }}
 
       # Mount Accept.json and Certs       
       volumes:

--- a/charts/snyk-broker/templates/cra_deployment.yaml
+++ b/charts/snyk-broker/templates/cra_deployment.yaml
@@ -46,11 +46,18 @@ spec:
               containerPort: {{ .Values.deployment.container.crSnykPort }}
           env:
             - name: SNYK_PORT
-              value: {{ .Values.deployment.container.crSnykPort | squote }} 
-         {{- if .Values.tlsRejectUnauthorized  }}
+              value: {{ .Values.deployment.container.crSnykPort | squote }}
+         {{- if .Values.crSnykMaxImageSizeBytes }}
+            - name: SNYK_MAX_IMAGE_SIZE_IN_BYTES
+              value: {{ .Values.crSnykMaxImageSizeBytes | squote }}
+         {{- end }}
+         {{- if .Values.tlsRejectUnauthorized }}
          # Troubleshooting - Set to 0 for SSL inspection testing
             - name: NODE_TLS_REJECT_UNAUTHORIZED
               value: "0"
+         {{- end }}
+         {{- if .Values.crAdditionalEnvironmentVariables }}
+            {{- toYaml .Values.crAdditionalEnvironmentVariables | nindent 12 }}
          {{- end }}
 
 

--- a/charts/snyk-broker/values.yaml
+++ b/charts/snyk-broker/values.yaml
@@ -131,6 +131,11 @@ crToken: ""
 # CRA Image tag. Do not adjust unless instructed by Snyk Representative
 crImage: "latest"
 
+##### Container Registry Additional Environment Variables #####
+# crAdditionalEnvironmentVariables:
+#   - name: foo
+#     value: bar
+
 
 ##### Code Agent #####
 
@@ -243,6 +248,11 @@ brokerResources:
    requests:
      cpu: 1
      memory: "256Mi"
+
+##### Broker Additional Environment Variables #####
+# brokerAdditionalEnvironmentVariables:
+#   - name: foo
+#     value: bar
 
 
 ##### Container Registry Agent Resource Values #####


### PR DESCRIPTION
Prior to this change, there was no way to pass additional variables to support either Snyk or node runtime.

This change allows to define additional variables to configure Snyk or node options.