### PR TITLE
feat: add override yaml file support for custom env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,3 +366,20 @@ Australia: ```https://deeproxy.au.snyk.io```<br>
 ```
 --set upstreamUrlCodeAgent=<UPSTREAM_URL>
 ```
+
+# Custom additional options
+
+If you need to inject additional option(s) via environment variables, use the override.yaml value file to add any additional environment variable you may need.
+
+Adding the `--values override.yaml` will load those values into your deployment.
+For example:
+
+```
+helm install snyk-broker-chart . \
+             --set scmType=github-com \
+             --set brokerToken=<ENTER_BROKER_TOKEN> \
+             --set scmToken=<ENTER_REPO_TOKEN> \
+             --set brokerClientUrl=<ENTER_BROKER_CLIENT_URL>:<ENTER_BROKER_CLIENT_PORT> \
+             --values override.yaml \
+             -n snyk-broker --create-namespace
+```

--- a/README.md
+++ b/README.md
@@ -367,7 +367,7 @@ Australia: ```https://deeproxy.au.snyk.io```<br>
 --set upstreamUrlCodeAgent=<UPSTREAM_URL>
 ```
 
-# Custom additional options
+## Custom additional options
 
 If you need to inject additional option(s) via environment variables, use the override.yaml value file to add any additional environment variable you may need.
 
@@ -381,5 +381,20 @@ helm install snyk-broker-chart . \
              --set scmToken=<ENTER_REPO_TOKEN> \
              --set brokerClientUrl=<ENTER_BROKER_CLIENT_URL>:<ENTER_BROKER_CLIENT_PORT> \
              --values override.yaml \
+             -n snyk-broker --create-namespace
+```
+
+
+The same can be achieved inline, without the override.yaml file if more convenient.
+```
+helm install snyk-broker-chart . \
+             --set scmType=github-com \
+             --set brokerToken=<ENTER_BROKER_TOKEN> \
+             --set scmToken=<ENTER_REPO_TOKEN> \
+             --set brokerClientUrl=<ENTER_BROKER_CLIENT_URL>:<ENTER_BROKER_CLIENT_PORT> \
+             --set env[0].name=myEnvVarName \
+             --set env[0].value=myEnvVarValue \
+             --set env[1].name=myOtherEnvVarName \
+             --set env[1].value=myOtherEnvVarValue \
              -n snyk-broker --create-namespace
 ```

--- a/charts/snyk-broker/templates/broker_deployment.yaml
+++ b/charts/snyk-broker/templates/broker_deployment.yaml
@@ -316,7 +316,11 @@ spec:
             - name: ACCEPT_IAC
               value: "tf,yaml,yml,json,tpl"
          {{- end }}
-
+        {{- range .Values.env }}
+         # custom env var in override.yaml
+            - name: {{ .name }}
+              value: {{ .value }} 
+        {{- end}}
       # Mount Accept.json and Certs       
       volumes:
       {{- if (include "snyk-broker.acceptJson" .)}}

--- a/charts/snyk-broker/templates/code_agent_deployment.yaml
+++ b/charts/snyk-broker/templates/code_agent_deployment.yaml
@@ -66,6 +66,11 @@ spec:
             - name: HTTPS_PROXY
               value: {{ .Values.httpsProxy }}
          {{- end }}
+         {{- range .Values.env }}
+         # custom env var in override.yaml
+            - name: {{ .name }}
+              value: {{ .value }} 
+        {{- end}}
         
 ---                     
 apiVersion: v1

--- a/charts/snyk-broker/templates/cra_deployment.yaml
+++ b/charts/snyk-broker/templates/cra_deployment.yaml
@@ -52,6 +52,11 @@ spec:
             - name: NODE_TLS_REJECT_UNAUTHORIZED
               value: "0"
          {{- end }}
+         {{- range .Values.env }}
+         # custom env var in override.yaml
+            - name: {{ .name }}
+              value: {{ .value }} 
+        {{- end}}
 
 
 ---

--- a/override.yaml
+++ b/override.yaml
@@ -1,0 +1,6 @@
+env:
+  # uncomment and update to use
+  # - name: MYENVVAR
+  #   value: myenvvarvalue
+  # - name: MYOTHERENVVAR
+  #   value: myothervalue


### PR DESCRIPTION
Adds a generic way to custom the helm chart with environment variable to facilitate iteration, instead of requiring change for every single new configuration option.