### PR TITLE
fix: rm auto rule injection for non scm types

### DIFF
--- a/charts/snyk-broker/Chart.yaml
+++ b/charts/snyk-broker/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: snyk-broker
-version: 1.1.11
+version: 1.1.12
 description: A Helm chart for Kubernetes
 type: application

--- a/charts/snyk-broker/templates/broker_deployment.yaml
+++ b/charts/snyk-broker/templates/broker_deployment.yaml
@@ -310,11 +310,13 @@ spec:
             - name: ACCEPT
               value: /home/node/private/accept.json
          {{ else }}
+          {{- if or (eq .Values.scmType "github-com") (eq .Values.scmType "github-enterprise") (eq .Values.scmType "bitbucket-server") (eq .Values.scmType "gitlab") (eq .Values.scmType "azure-repos") }}
          # Default Values to allow Snyk Code Snippets and Snyk IaC
             - name: ACCEPT_CODE
               value: "true"
             - name: ACCEPT_IAC
               value: "tf,yaml,yml,json,tpl"
+          {{- end}}
          {{- end }}
         {{- range .Values.env }}
          # custom env var in override.yaml


### PR DESCRIPTION
The [auto rule injection for Code and IAC](https://github.com/snyk/broker/#snyk-code) are only applicable to SCMs. The helm chart should not inject it for the other type of system the broker brokers access to.