### PR TITLE
fix: missing equal sign, Jira

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ helm install snyk-broker-chart snyk-broker/snyk-broker \
              --set brokerToken=<ENTER_BROKER_TOKEN> \
              --set jiraUsername=<ENTER_JIRA_USERNAME> \
              --set jiraPassword=<ENTER_JIRA_PASSWORD>  \
-             --set jiraHostname<ENTER_JIRA_HOSTNAME>  \
+             --set jiraHostname=<ENTER_JIRA_HOSTNAME>  \
              --set brokerClientUrl=<ENTER_BROKER_CLIENT_URL>:<ENTER_BROKER_CLIENT_PORT> \
              -n snyk-broker --create-namespace
 ```


### PR DESCRIPTION
In the line with "jiraHostname" there is an equal sign missing.