### PR TITLE
feat: consider-code-local-engine

### DIFF
--- a/charts/snyk-broker/templates/broker_deployment.yaml
+++ b/charts/snyk-broker/templates/broker_deployment.yaml
@@ -259,12 +259,15 @@ spec:
             - name: BROKER_CLIENT_VALIDATION_URL
               value: http://cra-service:{{ .Values.deployment.container.crSnykPort | toString }}/healthcheck
           {{- end }}
-         
-         # Code Agent
          {{- if .Values.enableCodeAgent }}
+         # Code Agent
             - name: GIT_CLIENT_URL
               value: {{ default (printf "http://code-agent-service:%s" (.Values.deployment.container.caSnykPort | toString)) .Values.gitClientUrl }}
-         {{- end }}     
+         {{- else if .Values.enableSnykCodeLocalEngine }}
+          # Snyk Code Local Engine
+            - name: GIT_CLIENT_URL
+              value: {{ tpl .Values.gitClientUrl . }}
+         {{- end }}        
          # Logging
             - name: LOG_LEVEL
               value: {{ .Values.logLevel }}
@@ -312,8 +315,10 @@ spec:
          {{ else }}
           {{- if or (eq .Values.scmType "github-com") (eq .Values.scmType "github-enterprise") (eq .Values.scmType "bitbucket-server") (eq .Values.scmType "gitlab") (eq .Values.scmType "azure-repos") }}
          # Default Values to allow Snyk Code Snippets and Snyk IaC
+            {{- if not .Values.enableSnykCodeLocalEngine}}
             - name: ACCEPT_CODE
               value: "true"
+            {{- end}}
             - name: ACCEPT_IAC
               value: "tf,yaml,yml,json,tpl"
           {{- end}}

--- a/charts/snyk-broker/values.yaml
+++ b/charts/snyk-broker/values.yaml
@@ -136,6 +136,7 @@ crImage: "latest"
 
 # Set to 'true' to enable Code Agent
 enableCodeAgent: ""
+
 # Only adjust this value if advised to by Snyk Representative. Used to upload content to non-standard environment. 
 upstreamUrlCodeAgent: ""
 
@@ -148,6 +149,10 @@ caImage: "latest"
 # Only adjust this value if advised to by Snyk Representative. This is the URL of the Snyk Code Agent. This helm chart already connects everything. 
 gitClientUrl: ""
 
+##### Snyk Code Local Engine #####
+
+# Set to 'true' to enable Snyk Code Local Engine
+enableSnykCodeLocalEngine: ""
 
 ##### Logging #####
 


### PR DESCRIPTION
As part of [NEBULA-1003](https://snyksec.atlassian.net/browse/NEBULA-1003)
This PR set the broker support snyk code local engine
We have added the need from local code engine of GIT_CLIENT_URL

also code agent and snyk code local engine cannot be supported in parallel, only one of them

[NEBULA-1003]: https://snyksec.atlassian.net/browse/NEBULA-1003?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ