### PR TITLE
feat: Adding support for extra K8s resources

### DIFF
--- a/charts/snyk-broker/templates/broker_deployment.yaml
+++ b/charts/snyk-broker/templates/broker_deployment.yaml
@@ -79,6 +79,9 @@ spec:
                 mountPath: /home/node/httpskey
                 readOnly: true
               {{- end }}              
+{{- if .Values.extraVolumeMounts }}
+{{ tpl (toYaml .Values.extraVolumeMounts | indent 14) . }}
+{{- end }}
           env:
             - name: BROKER_SERVER_URL
               value: {{ .Values.brokerServerUrl }}
@@ -350,3 +353,6 @@ spec:
         configMap:
           name: {{ include "snyk-broker.fullname" . }}-httpskey-configmap
       {{- end }}      
+{{- if .Values.extraVolumes }}
+{{ tpl (toYaml .Values.extraVolumes | indent 6) . }}
+{{- end }}

--- a/charts/snyk-broker/templates/extra-resources.yaml
+++ b/charts/snyk-broker/templates/extra-resources.yaml
@@ -1,0 +1,5 @@
+---
+{{ range .Values.extraObjects }}
+---
+{{ tpl (toYaml .) $ }}
+{{ end }}

--- a/charts/snyk-broker/values.yaml
+++ b/charts/snyk-broker/values.yaml
@@ -342,6 +342,16 @@ service:
   #      - chart-example.local
 
 
+##### Extra K8s resources, Volumes and VolumeMounts
+# These are useful when there is a need to introduce additional K8s resources (Drivers, Volumes, etc.) into the mix.
+# Secrets Store CSI Driver is one perfect example that can utilize these
+extraObjects: []
+
+extraVolumes: []
+
+extraVolumeMounts: []
+
+
 ##### Do not adjust these settings. The Broker is not deigned to work with multiple replicas
 
 autoscaling:


### PR DESCRIPTION
Providing options to inject extra K8s manifests using values files.

This will afford users the ability to bring their own resources into the mix. Resources that help support their helm deployment. 
An apt use case for this is when needing to source secrets on the fly by leveraging the Secrets Store CSI Driver.

The helm chart currently expects users to provide SCM credentials in plain text or backed by secret created with same name external to this helm chart.   With this PR, users will be able to source necessary secrets using Secrets Store CSI Driver.
