### PR TITLE
feat: add support for Nexus

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Gitlab: ```gitlab```<br>
 Azure Repos: ```azure-repos```<br>
 Artifactory: ```artifactory```<br>
 Nexus: `nexus` <br>
+Nexus2: `nexus2` <br>
 Jira: ```jira```<br>
 Container Registry Agent: ```container-registry-agent```<br>
 
@@ -114,6 +115,18 @@ helm install snyk-broker-chart snyk-broker/snyk-broker \
              -n snyk-broker --create-namespace
 ```
 
+### Nexus 2
+<b>Note: for `baseNexusUrl` and `nexusUrl` values include `https://`</b>
+```
+helm install snyk-broker-chart snyk-broker/snyk-broker \
+             --set scmType=nexus2 \
+             --set brokerToken=<ENTER_BROKER_TOKEN> \
+             --set baseNexusUrl=<ENTER_BASE_NEXUS_URL> \
+             --set nexusUrl=<ENTER_NEXUS_URL>
+             --set brokerClientValidationUrl=<ENTER_BROKER_CLIENT_VALIDATION_URL> \
+             -n snyk-broker --create-namespace
+```
+
 ### Jira
 <b>Note: for ```jiraHostname``` value do not include ```https://``` </b>
 ```
@@ -143,7 +156,7 @@ helm install snyk-broker-chart snyk-broker/snyk-broker \
              --set crPassword=<ENTER_CR_PASSWORD> \
              --set acceptJsonFile=accept.json \
              -n snyk-broker --create-namespace
-```            
+```
 <b> Allowed values for </b> ```crType```:
 
 ```artifactory-cr```<br>
@@ -176,7 +189,7 @@ helm install snyk-broker-chart snyk-broker/snyk-broker \
              --set crExternalId=<ENTER_CR_EXTERNAL_ID> \
              --set acceptJsonFile=accept.json \
              -n snyk-broker --create-namespace
-```            
+```
 
 #### DigitalOcean Container Registry (digitalocean-cr)
 * crToken
@@ -191,7 +204,7 @@ helm install snyk-broker-chart snyk-broker/snyk-broker \
              --set crToken=<ENTER_CR_TOKEN> \
              --set acceptJsonFile=accept.json \
              -n snyk-broker --create-namespace
-```            
+```
 
 ## Snyk Code Agent
 To deploy the Snyk Code Agent, you must set the ```enableCodeAgent``` flag to ```true```. See more information about the [Snyk Code Agent](https://docs.snyk.io/features/snyk-broker/snyk-broker-code-agent). Ensure you have the proper entries in the accept.json file. Grab the example file for the appropriate SCM [HERE](https://github.com/snyk/broker/tree/master/client-templates). Ensure you have the additional entries as specified by the Snyk Code Agent documentation.
@@ -257,7 +270,7 @@ There are two options available for ingress traffic. By default, the pods are no
 ### Load Balancer
 To enable a load balancer, add the ```--set service.<service-type>=LoadBalancer```. Allowed values are ```brokertype```, ```crType```, and ```caType```
 
-Example for Github:
+Example for GitHub:
 
 ```
 helm install snyk-broker-chart snyk-broker/snyk-broker \

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Container Registry Agent: ```container-registry-agent```<br>
 
 The following examples will create a namespace called ```snyk-broker```. To deploy into an existing namespace, adjust the ```-n``` parameter and delete the ```--create-namespace``` parameter.
 
-### Github.com
+### GitHub.com
 
 ```
 helm install snyk-broker-chart snyk-broker/snyk-broker \
@@ -35,7 +35,7 @@ helm install snyk-broker-chart snyk-broker/snyk-broker \
              --set brokerClientUrl=<ENTER_BROKER_CLIENT_URL>:<ENTER_BROKER_CLIENT_PORT> \
              -n snyk-broker --create-namespace
 ```
-### Github Enterprise
+### GitHub Enterprise
 <b>Note: for ```github```, ```githubApi``` and ```githubGraphQl``` values do not include ```https://``` </b>
 ```
 helm install snyk-broker-chart snyk-broker/snyk-broker \
@@ -64,7 +64,7 @@ helm install snyk-broker-chart snyk-broker/snyk-broker \
              -n snyk-broker --create-namespace
 ```
 
-### Gitlab
+### GitLab
 
 <b>Note: for ```gitlab``` value do not include ```https://``` </b>
 
@@ -113,6 +113,7 @@ helm install snyk-broker-chart snyk-broker/snyk-broker \
              --set brokerClientUrl=<ENTER_BROKER_CLIENT_URL>:<ENTER_BROKER_CLIENT_PORT> \
              -n snyk-broker --create-namespace
 ```
+
 ## Container Registry Agent
  While the documentation for the [Snyk Broker](https://github.com/snyk/broker) requires the parameter ```CR_AGENT_URL```, it is not required in this case. 
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Bitbucket: ```bitbucket-server```<br>
 Gitlab: ```gitlab```<br>
 Azure Repos: ```azure-repos```<br>
 Artifactory: ```artifactory```<br>
+Nexus: `nexus` <br>
 Jira: ```jira```<br>
 Container Registry Agent: ```container-registry-agent```<br>
 
@@ -98,6 +99,18 @@ helm install snyk-broker-chart snyk-broker/snyk-broker \
              --set scmType=artifactory \
              --set brokerToken=<ENTER_BROKER_TOKEN> \
              --set artifactoryUrl=<ENTER_ARTIFACTORY_URL> \
+             -n snyk-broker --create-namespace
+```
+
+### Nexus
+<b>Note: for `baseNexusUrl` and `nexusUrl` values include `https://`</b>
+```
+helm install snyk-broker-chart snyk-broker/snyk-broker \
+             --set scmType=nexus \
+             --set brokerToken=<ENTER_BROKER_TOKEN> \
+             --set baseNexusUrl=<ENTER_BASE_NEXUS_URL> \
+             --set nexusUrl=<ENTER_NEXUS_URL>
+             --set brokerClientValidationUrl=<ENTER_BROKER_CLIENT_VALIDATION_URL> \
              -n snyk-broker --create-namespace
 ```
 

--- a/charts/snyk-broker/templates/broker_deployment.yaml
+++ b/charts/snyk-broker/templates/broker_deployment.yaml
@@ -200,8 +200,8 @@ spec:
             - name: ARTIFACTORY_URL
               value: {{ .Values.artifactoryUrl }}
           {{- end }}
-          {{- if eq .Values.scmType "nexus" }}
-          # Nexus
+          {{- if or (eq .Values.scmType "nexus") (eq .Values.scmType "nexus2") }}
+          # Nexus (3 or 2)
             - name: BROKER_TOKEN
               valueFrom:
                 secretKeyRef:

--- a/charts/snyk-broker/templates/broker_deployment.yaml
+++ b/charts/snyk-broker/templates/broker_deployment.yaml
@@ -200,6 +200,20 @@ spec:
             - name: ARTIFACTORY_URL
               value: {{ .Values.artifactoryUrl }}
           {{- end }}
+          {{- if eq .Values.scmType "nexus" }}
+          # Nexus
+            - name: BROKER_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: { { .Values.scmType } }-broker-token
+                  key: "{{ .Values.scmType}}-broker-token-key"
+            - name: BASE_NEXUS_URL
+              value: {{ .Values.baseNexusUrl }}
+            - name: NEXUS_URL
+              value: {{ .Values.nexusUrl }}
+            - name: BROKER_CLIENT_VALIDATION_URL
+              value: {{ .Values.brokerClientValidationUrl }}
+          {{- end }}
           {{- if eq .Values.scmType "jira" }}
           # Jira
             - name: BROKER_TOKEN

--- a/charts/snyk-broker/templates/broker_deployment.yaml
+++ b/charts/snyk-broker/templates/broker_deployment.yaml
@@ -78,7 +78,7 @@ spec:
               - name: {{ include "snyk-broker.fullname" . }}-httpskey-volume
                 mountPath: /home/node/httpskey
                 readOnly: true
-              {{- end }}              
+              {{- end }}
           env:
             - name: BROKER_SERVER_URL
               value: {{ .Values.brokerServerUrl }}
@@ -87,7 +87,7 @@ spec:
             - name: BROKER_SYSTEMCHECK_PATH
               value: {{ .Values.systemCheckPath }}
           {{- if eq .Values.scmType "github-com" }}
-       # Github
+          # GitHub
             - name: BROKER_TOKEN
               valueFrom:
                 secretKeyRef:
@@ -104,7 +104,7 @@ spec:
               value: {{ .Values.brokerClientUrl }}
           {{- end }}
           {{- if eq .Values.scmType "github-enterprise" }}
-        # Github Enterprise
+          # GitHub Enterprise
             - name: BROKER_TOKEN
               valueFrom:
                 secretKeyRef:
@@ -120,7 +120,7 @@ spec:
             - name: GITHUB_API
               value: {{ .Values.githubApi }}
             - name: GITHUB_GRAPHQL
-              value: {{ .Values.githubGraphQl}}              
+              value: {{ .Values.githubGraphQl}}
             - name: PORT
               value: {{ .Values.deployment.container.containerPort | squote }}
             - name: BROKER_CLIENT_URL
@@ -128,7 +128,7 @@ spec:
 
           {{- end }}
           {{- if eq .Values.scmType "bitbucket-server" }}
-        # Bitbucket
+          # Bitbucket
             - name: BROKER_TOKEN
               valueFrom:
                 secretKeyRef:
@@ -144,14 +144,14 @@ spec:
             - name: BITBUCKET
               value: {{ .Values.bitbucket }}
             - name: BITBUCKET_API
-              value: {{ .Values.bitbucketApi }}              
+              value: {{ .Values.bitbucketApi }}
             - name: PORT
               value: {{ .Values.deployment.container.containerPort | squote }}
             - name: BROKER_CLIENT_URL
               value: {{ .Values.brokerClientUrl }}
           {{- end }}
           {{- if eq .Values.scmType "gitlab" }}
-         # Gitlab
+          # GitLab
             - name: BROKER_TOKEN
               valueFrom:
                 secretKeyRef:
@@ -163,7 +163,7 @@ spec:
                   name: {{ .Values.scmType}}-token
                   key: "{{ .Values.scmType}}-token-key"
             - name: GITLAB
-              value: {{ .Values.gitlab }}              
+              value: {{ .Values.gitlab }}
             - name: PORT
               value: {{ .Values.deployment.container.containerPort | squote }}
             - name: BROKER_CLIENT_URL
@@ -184,7 +184,7 @@ spec:
             - name: AZURE_REPOS_ORG
               value: {{ .Values.azureReposOrg }}
             - name: AZURE_REPOS_HOST
-              value: {{ .Values.azureReposHost }}        
+              value: {{ .Values.azureReposHost }}
             - name: PORT
               value: {{ .Values.deployment.container.containerPort | squote }}
             - name: BROKER_CLIENT_URL
@@ -215,7 +215,7 @@ spec:
                   name: {{ .Values.scmType}}-token
                   key: "{{ .Values.scmType}}-token-key"
             - name: JIRA_HOSTNAME
-              value: {{ .Values.jiraHostname }}        
+              value: {{ .Values.jiraHostname }}
             - name: PORT
               value: {{ .Values.deployment.container.containerPort | squote }}
             - name: BROKER_CLIENT_URL
@@ -233,14 +233,14 @@ spec:
             - name: CR_TYPE
               value: {{ .Values.crType }}
             - name: CR_BASE
-              value: {{ .Values.crBase }} 
+              value: {{ .Values.crBase }}
             - name: CR_USERNAME
-              value: {{ .Values.crUsername }}  
+              value: {{ .Values.crUsername }}
             - name: CR_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ .Values.scmType}}-token
-                  key: "{{ .Values.scmType}}-token-key"                   
+                  key: "{{ .Values.scmType}}-token-key"
             - name: CR_TOKEN
               valueFrom:
                 secretKeyRef:
@@ -328,7 +328,7 @@ spec:
             - name: {{ .name }}
               value: {{ .value }} 
         {{- end}}
-      # Mount Accept.json and Certs       
+      # Mount Accept.json and Certs
       volumes:
       {{- if (include "snyk-broker.acceptJson" .)}}
       - name: {{ include "snyk-broker.fullname" . }}-accept-volume

--- a/charts/snyk-broker/values.yaml
+++ b/charts/snyk-broker/values.yaml
@@ -90,6 +90,18 @@ azureReposToken: ""
 artifactoryUrl: ""
 
 
+##### Nexus #####
+
+# Nexus Base URL - include HTTPS
+baseNexusUrl: ""
+
+# Nexus URL - include HTTPS
+nexusUrl: ""
+
+# Nexus Validation URL, checked by broker client systemcheck endpoint.
+brokerClientValidationUrl: ""
+
+
 ##### Jira #####
 
 # Jira Username

--- a/charts/snyk-broker/values.yaml
+++ b/charts/snyk-broker/values.yaml
@@ -24,10 +24,10 @@ brokerServerUrl: "https://broker.snyk.io"
 # scmType is used to define the Source Control that you are connecting to. 
 
 # Allowed values for scmType:
-#   Github.com: github-com
-#   Github Enterprise: github-enterprise
+#   GitHub.com: github-com
+#   GitHub Enterprise: github-enterprise
 #   Bitbucket: bitbucket-server
-#   Gitlab: gitlab
+#   GitLab: gitlab
 #   Azure Repos: azure-repos
 #   Artifactory: artifactory
 #   Jira: jira

--- a/charts/snyk-broker/values.yaml
+++ b/charts/snyk-broker/values.yaml
@@ -30,6 +30,8 @@ brokerServerUrl: "https://broker.snyk.io"
 #   GitLab: gitlab
 #   Azure Repos: azure-repos
 #   Artifactory: artifactory
+#   Nexus: nexus
+#   Nexus2: nexus2
 #   Jira: jira
 #   Container Registry Agent: container-registry-agent
 
@@ -90,7 +92,7 @@ azureReposToken: ""
 artifactoryUrl: ""
 
 
-##### Nexus #####
+##### Nexus 2 & 3 #####
 
 # Nexus Base URL - include HTTPS
 baseNexusUrl: ""


### PR DESCRIPTION
This PR adds support for following scmTypes:
- nexus (version 3 as default)
- nexus2 (version 2)

Corresponding env.values:
- nexus: https://github.com/snyk/broker/blob/master/client-templates/nexus/.env.sample
- nexus2: https://github.com/snyk/broker/blob/master/client-templates/nexus2/.env.sample