### PR TITLE
Feature/add image pull secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,11 @@ helm install snyk-broker-chart snyk-broker/snyk-broker \
 ## Secrets
 API Tokens and or Passwords use Kubernetes Secrets. Existing secrets can be used, they just need to be created in the following formats.
 
+## Image repository, tag and Image Pull Secret
+You can choose to use your own container registry and tag instead of the public images by customizing the values.yaml file to specify your container registry uri and tag.
+
+If your container registry require an image pull secret, you can specify an image secret. Note that the Image Pull Secret is NOT created by the chart but rather expected to be present on your cluster.
+
 ### Broker Tokens
 ```
 apiVersion: v1

--- a/charts/snyk-broker/Chart.yaml
+++ b/charts/snyk-broker/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: snyk-broker
-version: 1.1.12
+version: 1.2.0
 description: A Helm chart for Kubernetes
 type: application

--- a/charts/snyk-broker/templates/broker_deployment.yaml
+++ b/charts/snyk-broker/templates/broker_deployment.yaml
@@ -21,6 +21,10 @@ spec:
       labels:
         {{- include "snyk-broker.selectorLabels" . | nindent 8 }}
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       serviceAccountName: {{ include "snyk-broker.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}

--- a/charts/snyk-broker/templates/code_agent_deployment.yaml
+++ b/charts/snyk-broker/templates/code_agent_deployment.yaml
@@ -25,6 +25,10 @@ spec:
         app.kubernetes.io/name: {{ .Release.Name }}-ca
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       serviceAccountName: {{ include "snyk-broker.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}

--- a/charts/snyk-broker/templates/cra_deployment.yaml
+++ b/charts/snyk-broker/templates/cra_deployment.yaml
@@ -25,6 +25,10 @@ spec:
         app.kubernetes.io/name: {{ .Release.Name }}-cr
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       serviceAccountName: {{ include "snyk-broker.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}

--- a/charts/snyk-broker/values.yaml
+++ b/charts/snyk-broker/values.yaml
@@ -232,6 +232,11 @@ brokerReadinessProbe:
     failureThreshold: 3
 
 
+##### Broker Image Pull Secrets Parameters #####
+
+imagePullSecrets: []
+# - name: registrySecretName
+
 ##### Broker Resource Values #####
 brokerResources:
    limits:

--- a/charts/snyk-broker/values.yaml
+++ b/charts/snyk-broker/values.yaml
@@ -222,6 +222,10 @@ image:
   # Overrides the image tag. If left empty the latest version is used
   tag: ""
 
+##### Broker Image Pull Secrets Parameters #####
+imagePullSecrets: []
+# - name: registrySecretName
+
 # Health and System Check Paths for the broker
 healthCheckPath: &healthCheckPath "/healthcheck"
 systemCheckPath: &systemCheckPath "/systemcheck"
@@ -245,12 +249,6 @@ brokerReadinessProbe:
     periodSeconds: 10
     timeoutSeconds: 1
     failureThreshold: 3
-
-
-##### Broker Image Pull Secrets Parameters #####
-
-imagePullSecrets: []
-# - name: registrySecretName
 
 ##### Broker Resource Values #####
 brokerResources:


### PR DESCRIPTION
From PR #11, The helm chart currently does not support imagePullSecrets which prevents us from pulling the images from our internal private registry.

This PR adds the missing functionality.

Let me know if you want me to bump the version in the Chart.yaml as part of this PR.

Extra commit: Adding readme notes.