### PR TITLE
feat: add extra K8S resources and objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -436,3 +436,10 @@ helm install snyk-broker-chart . \
              --set env[1].value=myOtherEnvVarValue \
              -n snyk-broker --create-namespace
 ```
+
+### Extra resources
+
+Additional kubernetes resources can be added in the chart but adding them to the values file.
+Be cautious using the right syntax and validate the rendered yaml using `helm template` command.
+
+thanks https://github.com/apat292 for the contribution !

--- a/charts/snyk-broker/Chart.yaml
+++ b/charts/snyk-broker/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: snyk-broker
-version: 1.3.0
+version: 1.4.0
 description: A Helm chart for Kubernetes
 type: application

--- a/charts/snyk-broker/templates/broker_deployment.yaml
+++ b/charts/snyk-broker/templates/broker_deployment.yaml
@@ -82,7 +82,10 @@ spec:
               - name: {{ include "snyk-broker.fullname" . }}-httpskey-volume
                 mountPath: /home/node/httpskey
                 readOnly: true
-              {{- end }}
+              {{- end }}              
+{{- if .Values.extraVolumeMounts }}
+{{ tpl (toYaml .Values.extraVolumeMounts | indent 14) . }}
+{{- end }}
           env:
             - name: BROKER_SERVER_URL
               value: {{ .Values.brokerServerUrl }}
@@ -368,3 +371,6 @@ spec:
         configMap:
           name: {{ include "snyk-broker.fullname" . }}-httpskey-configmap
       {{- end }}      
+{{- if .Values.extraVolumes }}
+{{ tpl (toYaml .Values.extraVolumes | indent 6) . }}
+{{- end }}

--- a/charts/snyk-broker/templates/extra-resources.yaml
+++ b/charts/snyk-broker/templates/extra-resources.yaml
@@ -1,0 +1,5 @@
+---
+{{ range .Values.extraObjects }}
+---
+{{ tpl (toYaml .) $ }}
+{{ end }}

--- a/charts/snyk-broker/values.yaml
+++ b/charts/snyk-broker/values.yaml
@@ -393,6 +393,14 @@ brokerIngress:
   #    hosts:
   #      - chart-example.local
 
+##### Extra K8s resources, Volumes and VolumeMounts
+# These are useful when there is a need to introduce additional K8s resources (Drivers, Volumes, etc.) into the mix.
+# Secrets Store CSI Driver is one perfect example that can utilize these
+extraObjects: []
+
+extraVolumes: []
+
+extraVolumeMounts: []
 
 ##### Do not adjust these settings. The Broker is not deigned to work with multiple replicas
 


### PR DESCRIPTION
Providing options to inject extra K8s manifests using values files.

This will afford users the ability to bring their own resources into the mix. Resources that help support their helm deployment.
An apt use case for this is when needing to source secrets on the fly by leveraging the Secrets Store CSI Driver.

The helm chart currently expects users to provide SCM credentials in plain text or backed by secret created with same name external to this helm chart. With this PR, users will be able to source necessary secrets using Secrets Store CSI Driver.

[Original PR](https://github.com/snyk/snyk-broker-helm/pull/53)