### PR TITLE
feat: add injection of extra pod specs

### DIFF
--- a/charts/snyk-broker/Chart.yaml
+++ b/charts/snyk-broker/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: snyk-broker
-version: 1.4.0
+version: 1.5.0
 description: A Helm chart for Kubernetes
 type: application

--- a/charts/snyk-broker/templates/broker_deployment.yaml
+++ b/charts/snyk-broker/templates/broker_deployment.yaml
@@ -62,6 +62,9 @@ spec:
               path: {{ .Values.brokerReadinessProbe.path }}
             {{- toYaml .Values.brokerReadinessProbe.config | nindent 12 }}
           {{- end }}
+          {{- if .Values.extraPodSpecs }}
+          {{- toYaml .Values.extraPodSpecs | nindent 10 }}
+          {{- end }}
           volumeMounts:
               {{- if (include "snyk-broker.acceptJson" .)}}
               - name: {{ include "snyk-broker.fullname" . }}-accept-volume

--- a/charts/snyk-broker/values.yaml
+++ b/charts/snyk-broker/values.yaml
@@ -402,7 +402,14 @@ extraVolumes: []
 
 extraVolumeMounts: []
 
-##### Do not adjust these settings. The Broker is not deigned to work with multiple replicas
+extraPodSpecs: 
+  # tolerations:
+  # - key: "networking/something"
+  #   operator: "Equal"
+  #   value: "internal-pods"
+  #   effect: "NoSchedule"
+
+##### Do not adjust these settings. The Broker is not designed to work with multiple replicas
 
 autoscaling:
   enabled: false


### PR DESCRIPTION
Allows for the injection of additional pod specs parameters in the deployment definition, so specific things such as tolerations can be added.