### PR TITLE
Removed section to include the accept.json verbatim in the values.yaml file

### DIFF
--- a/charts/snyk-broker/values.yaml
+++ b/charts/snyk-broker/values.yaml
@@ -207,16 +207,8 @@ httpProxy: ""
 # HTTPS Proxy URL - This will apply to both Snyk Broker and Snyk Code Agent
 httpsProxy: ""
 
-# For custom accept.json
-# Specify the accept.json file contents verbatim. Should look something like:
-# acceptJson: |-
-#   {
-#    "public": [
-#      {
-#        "//": "used for pushing up webhooks from github",
-#        "method": "POST",
-#        "path": "/webhook/github",
-
+# For custom accept.json, specify the path to the accept.json using the --set-file command when installing 
+the chart
 acceptJson: ""
 
 ##### Broker Image Parameters #####

--- a/charts/snyk-broker/values.yaml
+++ b/charts/snyk-broker/values.yaml
@@ -207,8 +207,7 @@ httpProxy: ""
 # HTTPS Proxy URL - This will apply to both Snyk Broker and Snyk Code Agent
 httpsProxy: ""
 
-# For custom accept.json, specify the path to the accept.json using the --set-file command when installing 
-the chart
+# For custom accept.json, specify the path to the accept.json using the --set-file command when installing the chart
 acceptJson: ""
 
 ##### Broker Image Parameters #####


### PR DESCRIPTION
This PR removes the example to add the `accept.json` file verbatim in the values.yaml file. This didn't work correctly.

Instead the `acceptJson` value can be set by specifying the path of `accept.json` with the set-file command while installing the chart.

This documentation [here](https://docs.snyk.io/enterprise-setup/snyk-broker/install-and-configure-snyk-broker/advanced-configuration-for-helm-chart-installation/adding-custom-accept.json-for-helm-installation) needs to be updated to reflect this.