### PR TITLE
chore: add secrets-scan step for circleci [ED-262]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,13 @@
+version: 2.1
+
+orbs:
+  prodsec: snyk/prodsec-orb@1.0
+
+workflows:
+  scans:
+    jobs:
+      - prodsec/secrets-scan:
+          name: Scan repository for secrets
+          context:
+            - snyk-bot-slack
+          channel: broker-alerts

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,11 @@
+[extend]
+useDefault = true
+
+[allowlist]
+description = "global allow list"
+
+# ignoring historical secrets from past commits
+# (not present in the current codebase)
+commits = [
+  "9c8b32139b73111b618fc946a7f64355e8429423",
+]


### PR DESCRIPTION
This PR adds CircleCI integration and secret scans via `snyk/prodsec-orb`.