### PR TITLE
fix: add missing port env vars for private registries broker types

### DIFF
--- a/charts/snyk-broker/Chart.yaml
+++ b/charts/snyk-broker/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: snyk-broker
-version: 1.7.0
+version: 1.7.1
 description: A Helm chart for Kubernetes
 type: application

--- a/charts/snyk-broker/templates/broker_deployment.yaml
+++ b/charts/snyk-broker/templates/broker_deployment.yaml
@@ -214,6 +214,8 @@ spec:
                   key: "{{ .Values.scmType}}-broker-token-key"
             - name: ARTIFACTORY_URL
               value: {{ .Values.artifactoryUrl }}
+            - name: PORT
+              value: {{ .Values.deployment.container.containerPort | squote }}
           {{- end }}
           {{- if or (eq .Values.scmType "nexus") (eq .Values.scmType "nexus2") }}
           # Nexus (3 or 2)
@@ -235,6 +237,9 @@ spec:
               
             - name: BROKER_CLIENT_VALIDATION_URL
               value: {{ .Values.brokerClientValidationUrl }}
+
+            - name: PORT
+              value: {{ .Values.deployment.container.containerPort | squote }}
           {{- end }}
           {{- if eq .Values.scmType "jira" }}
           # Jira


### PR DESCRIPTION
Liveness checks fail otherwise as the ports don't match if missing. Broker run 7341 port by default instead of 8000.