### PR TITLE
fix: Add missing separators that prevent secrets from being created for nexus integration

### DIFF
--- a/charts/snyk-broker/templates/secrets.yaml
+++ b/charts/snyk-broker/templates/secrets.yaml
@@ -76,6 +76,7 @@ metadata:
 type: Opaque
 data:
   "snyk-token-key": {{ .Values.snykToken | b64enc | quote }}
+---
 {{- end }}
 {{- if .Values.baseNexusUrl }}
 apiVersion: v1
@@ -85,6 +86,7 @@ metadata:
 type: Opaque
 data:
   "nexus-base-nexus-url": {{ .Values.baseNexusUrl | b64enc | quote }}
+---
 {{- end}}
 {{- if .Values.nexusUrl }}
 apiVersion: v1


### PR DESCRIPTION
Hello,

just been caught by those missing separators that prevent secrets from being created for Nexus