### PR TITLE
Avoid collisions for multiple deployments of broker in 1 namespace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,5 @@ acceptcode.json
 acceptcontainer.json
 bitbucket.crt
 .dccache
+
+snyk-broker-1.7.2.tgz

--- a/charts/snyk-broker/templates/broker_deployment.yaml
+++ b/charts/snyk-broker/templates/broker_deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: "{{ .Values.scmType}}-broker"
+  name: "{{ .Values.scmType}}-broker-{{ .Values.number}}"
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "snyk-broker.labels" . | nindent 4 }}

--- a/charts/snyk-broker/templates/broker_deployment.yaml
+++ b/charts/snyk-broker/templates/broker_deployment.yaml
@@ -106,12 +106,12 @@ spec:
             - name: BROKER_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.scmType}}-broker-token
+                  name: {{ .Values.scmType}}-broker-token-{{ .Values.number}}
                   key: "{{ .Values.scmType}}-broker-token-key"
             - name: GITHUB_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.scmType}}-token
+                  name: {{ .Values.scmType}}-token-{{ .Values.number}}
                   key: "{{ .Values.scmType}}-token-key"
             - name: PORT
               value: {{ .Values.deployment.container.containerPort | squote }}
@@ -123,12 +123,12 @@ spec:
             - name: BROKER_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.scmType}}-broker-token
+                  name: {{ .Values.scmType}}-broker-token-{{ .Values.number}}
                   key: "{{ .Values.scmType}}-broker-token-key"
             - name: GITHUB_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.scmType}}-token
+                  name: {{ .Values.scmType}}-token-{{ .Values.number}}
                   key: "{{ .Values.scmType}}-token-key"
             - name: GITHUB
               value: {{ .Values.github }}
@@ -147,14 +147,14 @@ spec:
             - name: BROKER_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.scmType}}-broker-token
+                  name: {{ .Values.scmType}}-broker-token-{{ .Values.number}}
                   key: "{{ .Values.scmType}}-broker-token-key"
             - name: BITBUCKET_USERNAME
               value: {{ .Values.bitbucketUsername }}
             - name: BITBUCKET_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.scmType}}-token
+                  name: {{ .Values.scmType}}-token-{{ .Values.number}}
                   key: "{{ .Values.scmType}}-token-key"
             - name: BITBUCKET
               value: {{ .Values.bitbucket }}
@@ -170,12 +170,12 @@ spec:
             - name: BROKER_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.scmType}}-broker-token
+                  name: {{ .Values.scmType}}-broker-token-{{ .Values.number}}
                   key: "{{ .Values.scmType}}-broker-token-key"
             - name: GITLAB_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.scmType}}-token
+                  name: {{ .Values.scmType}}-token-{{ .Values.number}}
                   key: "{{ .Values.scmType}}-token-key"
             - name: GITLAB
               value: {{ .Values.gitlab }}
@@ -189,12 +189,12 @@ spec:
             - name: BROKER_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.scmType}}-broker-token
+                  name: {{ .Values.scmType}}-broker-token-{{ .Values.number}}
                   key: "{{ .Values.scmType}}-broker-token-key"
             - name: AZURE_REPOS_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.scmType}}-token
+                  name: {{ .Values.scmType}}-token-{{ .Values.number}}
                   key: "{{ .Values.scmType}}-token-key"
             - name: AZURE_REPOS_ORG
               value: {{ .Values.azureReposOrg }}
@@ -210,7 +210,7 @@ spec:
             - name: BROKER_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.scmType}}-broker-token
+                  name: {{ .Values.scmType}}-broker-token-{{ .Values.number}}
                   key: "{{ .Values.scmType}}-broker-token-key"
             - name: ARTIFACTORY_URL
               value: {{ .Values.artifactoryUrl }}
@@ -222,12 +222,12 @@ spec:
             - name: BROKER_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.scmType }}-broker-token
+                  name: {{ .Values.scmType }}-broker-token-{{ .Values.number}}
                   key: "{{ .Values.scmType}}-broker-token-key"
             - name: BASE_NEXUS_URL
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.scmType }}-base-nexus-url
+                  name: {{ .Values.scmType }}-base-nexus-url-{{ .Values.number}}
                   key: "{{ .Values.scmType}}-base-nexus-url"
             - name: NEXUS_URL
               valueFrom:
@@ -246,14 +246,14 @@ spec:
             - name: BROKER_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.scmType}}-broker-token
+                  name: {{ .Values.scmType}}-broker-token-{{ .Values.number}}
                   key: "{{ .Values.scmType}}-broker-token-key"
             - name: JIRA_USERNAME
               value: {{ .Values.jiraUsername }}
             - name: JIRA_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.scmType}}-token
+                  name: {{ .Values.scmType}}-token-{{ .Values.number}}
                   key: "{{ .Values.scmType}}-token-key"
             - name: JIRA_HOSTNAME
               value: {{ .Values.jiraHostname }}
@@ -267,7 +267,7 @@ spec:
             - name: BROKER_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.scmType}}-broker-token
+                  name: {{ .Values.scmType}}-broker-token-{{ .Values.number}}
                   key: "{{ .Values.scmType}}-broker-token-key"
             - name: CR_AGENT_URL
               value: http://cra-service:{{ .Values.deployment.container.crSnykPort | toString }}
@@ -280,12 +280,12 @@ spec:
             - name: CR_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.scmType}}-token
+                  name: {{ .Values.scmType}}-token-{{ .Values.number}}
                   key: "{{ .Values.scmType}}-token-key"
             - name: CR_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.scmType}}-token
+                  name: {{ .Values.scmType}}-token-{{ .Values.number}}
                   key: "{{ .Values.scmType}}-token-key"
             - name: CR_ROLE_ARN
               value: {{ .Values.crRoleArn }}

--- a/charts/snyk-broker/templates/broker_service.yaml
+++ b/charts/snyk-broker/templates/broker_service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: "{{ .Values.scmType}}-broker-service"
+  name: "{{ .Values.scmType}}-broker-service-{{ .Values.number}}"
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "snyk-broker.labels" . | nindent 4 }}

--- a/charts/snyk-broker/templates/secrets.yaml
+++ b/charts/snyk-broker/templates/secrets.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Values.scmType}}-broker-token
+  name: {{ .Values.scmType}}-broker-token-{{ .Values.number}}
 type: Opaque
 data:
   "{{ .Values.scmType}}-broker-token-key": {{ .Values.brokerToken | b64enc | quote }}
@@ -12,7 +12,7 @@ data:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Values.scmType}}-token
+  name: {{ .Values.scmType}}-token-{{ .Values.number}}
 type: Opaque
 data:
   "{{ .Values.scmType}}-token-key": {{ .Values.scmToken | b64enc | quote }}
@@ -22,7 +22,7 @@ data:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Values.scmType}}-token
+  name: {{ .Values.scmType}}-token-{{ .Values.number}}
 type: Opaque
 data:
   "{{ .Values.scmType}}-token-key": {{ .Values.bitbucketPassword | b64enc | quote }}
@@ -32,7 +32,7 @@ data:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Values.scmType}}-token
+  name: {{ .Values.scmType}}-token-{{ .Values.number}}
 type: Opaque
 data:
   "{{ .Values.scmType}}-token-key": {{ .Values.azureReposToken | b64enc | quote }}
@@ -42,7 +42,7 @@ data:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Values.scmType}}-token
+  name: {{ .Values.scmType}}-token-{{ .Values.number}}
 type: Opaque
 data:
   "{{ .Values.scmType}}-token-key": {{ .Values.jiraPassword | b64enc | quote }}
@@ -52,7 +52,7 @@ data:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Values.scmType}}-token
+  name: {{ .Values.scmType}}-token-{{ .Values.number}}
 type: Opaque
 data:
   "{{ .Values.scmType}}-token-key": {{ .Values.crPassword | b64enc | quote }}
@@ -62,7 +62,7 @@ data:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Values.scmType}}-token
+  name: {{ .Values.scmType}}-token-{{ .Values.number}}
 type: Opaque
 data:
   "{{ .Values.scmType}}-token-key": {{ .Values.crToken | b64enc | quote }}
@@ -72,7 +72,7 @@ data:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: snyk-token
+  name: snyk-token-{{ .Values.number}}
 type: Opaque
 data:
   "snyk-token-key": {{ .Values.snykToken | b64enc | quote }}
@@ -82,7 +82,7 @@ data:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: nexus-base-nexus-url
+  name: nexus-base-nexus-url-{{ .Values.number}}
 type: Opaque
 data:
   "nexus-base-nexus-url": {{ .Values.baseNexusUrl | b64enc | quote }}
@@ -92,7 +92,7 @@ data:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: nexus-nexus-url
+  name: nexus-nexus-url-{{ .Values.number}}
 type: Opaque
 data:
   "nexus-nexus-url": {{ .Values.nexusUrl | b64enc | quote }}

--- a/charts/snyk-broker/values.yaml
+++ b/charts/snyk-broker/values.yaml
@@ -24,7 +24,8 @@ brokerDispatcherUrl: "https://api.snyk.io"
 # This number if only used if enableHighAvailabilityMode is true
 replicaCount: 2
 
-
+# Adding number value to allow for multiple of the same brokers to be deployed in the same namespace
+number: 1
 
 ##### SCM Generic #####
 


### PR DESCRIPTION
There are a few resources created with the helm chart that would cause problems if you tried to run it again.

For example:
First run of the chart would create github-token as a secret within kubernetes.
If you tried to run that again, even with different values, the chart would fail to install because github-token would already exist as a secret.

This collision would happen for secrets, service accounts and even the name of the broker. I modified my version of the helm chart to add an additional number value.

This appends a number so that the secret would look like this:
github-token-1. I applied it to all of the affected resources I could see.
You can then set that value in the helm install command or by modifying the values.yaml file