### PR TITLE
feat: add support for multiple broker in same namespace

### DIFF
--- a/charts/snyk-broker/Chart.yaml
+++ b/charts/snyk-broker/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: snyk-broker
-version: 1.8.0
+version: 2.0.0
 description: A Helm chart for Kubernetes
 type: application

--- a/charts/snyk-broker/templates/_helpers.tpl
+++ b/charts/snyk-broker/templates/_helpers.tpl
@@ -46,7 +46,7 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 Selector labels
 */}}
 {{- define "snyk-broker.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "snyk-broker.name" . }}
+app.kubernetes.io/name: {{ include "snyk-broker.name" . }}-{{ .Release.Name }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 

--- a/charts/snyk-broker/templates/broker_deployment.yaml
+++ b/charts/snyk-broker/templates/broker_deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: "{{ .Values.scmType}}-broker"
+  name: "{{ .Values.scmType}}-broker-{{ .Release.Name }}"
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "snyk-broker.labels" . | nindent 4 }}
@@ -30,11 +30,11 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      serviceAccountName: {{ include "snyk-broker.serviceAccountName" . }}
+      serviceAccountName: {{ include "snyk-broker.serviceAccountName" . }}-{{ .Release.Name }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
-        - name: "{{ .Values.scmType}}-broker"
+        - name: "{{ .Values.scmType}}-broker-{{ .Release.Name }}"
           resources:
             limits:
               cpu: {{ .Values.brokerResources.limits.cpu }}
@@ -106,12 +106,12 @@ spec:
             - name: BROKER_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.scmType}}-broker-token
+                  name: {{ .Values.scmType}}-broker-token-{{ .Release.Name }}
                   key: "{{ .Values.scmType}}-broker-token-key"
             - name: GITHUB_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.scmType}}-token
+                  name: {{ .Values.scmType}}-token-{{ .Release.Name }}
                   key: "{{ .Values.scmType}}-token-key"
             - name: PORT
               value: {{ .Values.deployment.container.containerPort | squote }}
@@ -123,12 +123,12 @@ spec:
             - name: BROKER_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.scmType}}-broker-token
+                  name: {{ .Values.scmType}}-broker-token-{{ .Release.Name }}
                   key: "{{ .Values.scmType}}-broker-token-key"
             - name: GITHUB_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.scmType}}-token
+                  name: {{ .Values.scmType}}-token-{{ .Release.Name }}
                   key: "{{ .Values.scmType}}-token-key"
             - name: GITHUB
               value: {{ .Values.github }}
@@ -147,14 +147,14 @@ spec:
             - name: BROKER_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.scmType}}-broker-token
+                  name: {{ .Values.scmType}}-broker-token-{{ .Release.Name }}
                   key: "{{ .Values.scmType}}-broker-token-key"
             - name: BITBUCKET_USERNAME
               value: {{ .Values.bitbucketUsername }}
             - name: BITBUCKET_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.scmType}}-token
+                  name: {{ .Values.scmType}}-token-{{ .Release.Name }}
                   key: "{{ .Values.scmType}}-token-key"
             - name: BITBUCKET
               value: {{ .Values.bitbucket }}
@@ -170,12 +170,12 @@ spec:
             - name: BROKER_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.scmType}}-broker-token
+                  name: {{ .Values.scmType}}-broker-token-{{ .Release.Name }}
                   key: "{{ .Values.scmType}}-broker-token-key"
             - name: GITLAB_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.scmType}}-token
+                  name: {{ .Values.scmType}}-token-{{ .Release.Name }}
                   key: "{{ .Values.scmType}}-token-key"
             - name: GITLAB
               value: {{ .Values.gitlab }}
@@ -189,12 +189,12 @@ spec:
             - name: BROKER_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.scmType}}-broker-token
+                  name: {{ .Values.scmType}}-broker-token-{{ .Release.Name }}
                   key: "{{ .Values.scmType}}-broker-token-key"
             - name: AZURE_REPOS_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.scmType}}-token
+                  name: {{ .Values.scmType}}-token-{{ .Release.Name }}
                   key: "{{ .Values.scmType}}-token-key"
             - name: AZURE_REPOS_ORG
               value: {{ .Values.azureReposOrg }}
@@ -210,7 +210,7 @@ spec:
             - name: BROKER_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.scmType}}-broker-token
+                  name: {{ .Values.scmType}}-broker-token-{{ .Release.Name }}
                   key: "{{ .Values.scmType}}-broker-token-key"
             - name: ARTIFACTORY_URL
               value: {{ .Values.artifactoryUrl }}
@@ -222,17 +222,17 @@ spec:
             - name: BROKER_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.scmType }}-broker-token
+                  name: {{ .Values.scmType }}-broker-token-{{ .Release.Name }}
                   key: "{{ .Values.scmType}}-broker-token-key"
             - name: BASE_NEXUS_URL
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.scmType }}-base-nexus-url
+                  name: {{ .Values.scmType }}-base-nexus-url-{{ .Release.Name }}
                   key: "{{ .Values.scmType}}-base-nexus-url"
             - name: NEXUS_URL
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.scmType }}-nexus-url
+                  name: {{ .Values.scmType }}-nexus-url-{{ .Release.Name }}
                   key: "{{ .Values.scmType}}-nexus-url"
               
             - name: BROKER_CLIENT_VALIDATION_URL
@@ -246,14 +246,14 @@ spec:
             - name: BROKER_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.scmType}}-broker-token
+                  name: {{ .Values.scmType}}-broker-token-{{ .Release.Name }}
                   key: "{{ .Values.scmType}}-broker-token-key"
             - name: JIRA_USERNAME
               value: {{ .Values.jiraUsername }}
             - name: JIRA_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.scmType}}-token
+                  name: {{ .Values.scmType}}-token-{{ .Release.Name }}
                   key: "{{ .Values.scmType}}-token-key"
             - name: JIRA_HOSTNAME
               value: {{ .Values.jiraHostname }}
@@ -267,7 +267,7 @@ spec:
             - name: BROKER_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.scmType}}-broker-token
+                  name: {{ .Values.scmType}}-broker-token-{{ .Release.Name }}
                   key: "{{ .Values.scmType}}-broker-token-key"
             - name: CR_AGENT_URL
               value: http://cra-service:{{ .Values.deployment.container.crSnykPort | toString }}
@@ -280,12 +280,12 @@ spec:
             - name: CR_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.scmType}}-token
+                  name: {{ .Values.scmType}}-token-{{ .Release.Name }}
                   key: "{{ .Values.scmType}}-token-key"
             - name: CR_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.scmType}}-token
+                  name: {{ .Values.scmType}}-token-{{ .Release.Name }}
                   key: "{{ .Values.scmType}}-token-key"
             - name: CR_ROLE_ARN
               value: {{ .Values.crRoleArn }}
@@ -387,22 +387,22 @@ spec:
       {{- if (include "snyk-broker.acceptJson" .)}}
       - name: {{ include "snyk-broker.fullname" . }}-accept-volume
         configMap:
-          name: {{ include "snyk-broker.fullname" . }}-accept-configmap
+          name: {{ include "snyk-broker.fullname" . }}-accept-configmap-{{ .Release.Name }}
       {{- end }}
       {{- if .Values.caCert }}
       - name: {{ include "snyk-broker.fullname" . }}-cacert-volume
         configMap:
-          name: {{ include "snyk-broker.fullname" . }}-cacert-configmap
+          name: {{ include "snyk-broker.fullname" . }}-cacert-configmap-{{ .Release.Name }}
       {{- end }}
       {{- if .Values.httpsCert }}
       - name: {{ include "snyk-broker.fullname" . }}-httpscert-volume
         configMap:
-          name: {{ include "snyk-broker.fullname" . }}-httpscert-configmap
+          name: {{ include "snyk-broker.fullname" . }}-httpscert-configmap-{{ .Release.Name }}
       {{- end }}
       {{- if .Values.httpsKey }}
       - name: {{ include "snyk-broker.fullname" . }}-httpskey-volume
         configMap:
-          name: {{ include "snyk-broker.fullname" . }}-httpskey-configmap
+          name: {{ include "snyk-broker.fullname" . }}-httpskey-configmap-{{ .Release.Name }}
       {{- end }}      
 {{- if .Values.extraVolumes }}
 {{ tpl (toYaml .Values.extraVolumes | indent 6) . }}

--- a/charts/snyk-broker/templates/broker_ingress.yaml
+++ b/charts/snyk-broker/templates/broker_ingress.yaml
@@ -11,7 +11,7 @@
 apiVersion: {{ include "snyk-broker.ingress.apiVersion" . }}
 kind: Ingress
 metadata:
-  name: {{ $fullName }}
+  name: {{ $fullName }}-{{ .Release.Name }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "snyk-broker.labels" . | nindent 4 }}
@@ -48,11 +48,11 @@ spec:
             backend:
               {{- if $ingressApiIsStable }}
               service:
-                name: {{ $scmType }}-broker-service
+                name: {{ $scmType }}-broker-service-{{ .Release.Name }}
                 port:
                   number: {{ $servicePort }}
               {{- else }}
-              serviceName: {{ $scmType }}-broker-service
+              serviceName: {{ $scmType }}-broker-service-{{ .Release.Name }}
               servicePort: {{ $servicePort }}
               {{- end }}
   {{- end }}
@@ -62,11 +62,11 @@ spec:
           - backend:
               {{- if $ingressApiIsStable }}
               service:
-                name: {{ $scmType }}-broker-service
+                name: {{ $scmType }}-broker-service-{{ .Release.Name }}
                 port:
                   number: {{ $servicePort }}
               {{- else }}
-              serviceName: {{ $scmType }}-broker-service
+              serviceName: {{ $scmType }}-broker-service-{{ .Release.Name }}
               servicePort: {{ $servicePort }}
               {{- end }}
             {{- if $ingressPath }}

--- a/charts/snyk-broker/templates/broker_service.yaml
+++ b/charts/snyk-broker/templates/broker_service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: "{{ .Values.scmType}}-broker-service"
+  name: "{{ .Values.scmType}}-broker-service-{{ .Release.Name }}"
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "snyk-broker.labels" . | nindent 4 }}

--- a/charts/snyk-broker/templates/cacert_configmap.yaml
+++ b/charts/snyk-broker/templates/cacert_configmap.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "snyk-broker.fullname" . }}-cacert-configmap
+  name: {{ include "snyk-broker.fullname" . }}-cacert-configmap-{{ .Release.Name }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "snyk-broker.labels" . | nindent 4 }}
@@ -14,7 +14,7 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "snyk-broker.fullname" . }}-cacert-configmap
+  name: {{ include "snyk-broker.fullname" . }}-cacert-configmap-{{ .Release.Name }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "snyk-broker.labels" . | nindent 4 }}

--- a/charts/snyk-broker/templates/code_agent_deployment.yaml
+++ b/charts/snyk-broker/templates/code_agent_deployment.yaml
@@ -2,7 +2,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: "{{ .Values.scmType}}-code-agent"
+  name: "{{ .Values.scmType}}-code-agent-{{ .Release.Name }}"
   namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ .Release.Name }}-ca
@@ -29,7 +29,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      serviceAccountName: {{ include "snyk-broker.serviceAccountName" . }}
+      serviceAccountName: {{ include "snyk-broker.serviceAccountName" . }}-{{ .Release.Name }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
@@ -80,7 +80,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: "code-agent-service"
+  name: "code-agent-service-{{ .Release.Name }}"
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "snyk-broker.labels" . | nindent 4 }}

--- a/charts/snyk-broker/templates/cra_deployment.yaml
+++ b/charts/snyk-broker/templates/cra_deployment.yaml
@@ -2,10 +2,10 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: "{{ .Values.scmType}}-cra"
+  name: "{{ .Values.scmType}}-cra-{{ .Release.Name }}"
   namespace: {{ .Release.Namespace }}
   labels:
-    app.kubernetes.io/name: {{ .Release.Name }}-cr
+    app.kubernetes.io/name: {{ .Release.Name }}-cr-{{ .Release.Name }}
     app.kubernetes.io/instance: {{ .Release.Name }}
 spec:
   {{- if not .Values.autoscaling.enabled }}
@@ -13,7 +13,7 @@ spec:
   {{- end }}
   selector:
     matchLabels:
-      app.kubernetes.io/name: {{ .Release.Name }}-cr
+      app.kubernetes.io/name: {{ .Release.Name }}-cr-{{ .Release.Name }}
       app.kubernetes.io/instance: {{ .Release.Name }}
   template:
     metadata:
@@ -22,7 +22,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
-        app.kubernetes.io/name: {{ .Release.Name }}-cr
+        app.kubernetes.io/name: {{ .Release.Name }}-cr-{{ .Release.Name }}
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
       {{- with .Values.imagePullSecrets }}
@@ -33,7 +33,7 @@ spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
-        - name: container-registry-agent
+        - name: container-registry-agent-{{ .Release.Name }}
           resources:
             limits:
               cpu: {{ .Values.crResources.limits.cpu }}
@@ -67,7 +67,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: "cra-service"
+  name: "cra-service-{{ .Release.Name }}"
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "snyk-broker.labels" . | nindent 4 }}

--- a/charts/snyk-broker/templates/httpscert_configmap.yaml
+++ b/charts/snyk-broker/templates/httpscert_configmap.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "snyk-broker.fullname" . }}-httpscert-configmap
+  name: {{ include "snyk-broker.fullname" . }}-httpscert-configmap-{{ .Release.Name }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "snyk-broker.labels" . | nindent 4 }}

--- a/charts/snyk-broker/templates/httpskey_configmap.yaml
+++ b/charts/snyk-broker/templates/httpskey_configmap.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "snyk-broker.fullname" . }}-httpskey-configmap
+  name: {{ include "snyk-broker.fullname" . }}-httpskey-configmap-{{ .Release.Name }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "snyk-broker.labels" . | nindent 4 }}

--- a/charts/snyk-broker/templates/secrets.yaml
+++ b/charts/snyk-broker/templates/secrets.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Values.scmType}}-broker-token
+  name: {{ .Values.scmType}}-broker-token-{{ .Release.Name }}
 type: Opaque
 data:
   "{{ .Values.scmType}}-broker-token-key": {{ .Values.brokerToken | b64enc | quote }}
@@ -12,7 +12,7 @@ data:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Values.scmType}}-token
+  name: {{ .Values.scmType}}-token-{{ .Release.Name }}
 type: Opaque
 data:
   "{{ .Values.scmType}}-token-key": {{ .Values.scmToken | b64enc | quote }}
@@ -22,7 +22,7 @@ data:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Values.scmType}}-token
+  name: {{ .Values.scmType}}-token-{{ .Release.Name }}
 type: Opaque
 data:
   "{{ .Values.scmType}}-token-key": {{ .Values.bitbucketPassword | b64enc | quote }}
@@ -32,7 +32,7 @@ data:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Values.scmType}}-token
+  name: {{ .Values.scmType}}-token-{{ .Release.Name }}
 type: Opaque
 data:
   "{{ .Values.scmType}}-token-key": {{ .Values.azureReposToken | b64enc | quote }}
@@ -42,7 +42,7 @@ data:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Values.scmType}}-token
+  name: {{ .Values.scmType}}-token-{{ .Release.Name }}
 type: Opaque
 data:
   "{{ .Values.scmType}}-token-key": {{ .Values.jiraPassword | b64enc | quote }}
@@ -52,7 +52,7 @@ data:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Values.scmType}}-token
+  name: {{ .Values.scmType}}-token-{{ .Release.Name }}
 type: Opaque
 data:
   "{{ .Values.scmType}}-token-key": {{ .Values.crPassword | b64enc | quote }}
@@ -62,7 +62,7 @@ data:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Values.scmType}}-token
+  name: {{ .Values.scmType}}-token-{{ .Release.Name }}
 type: Opaque
 data:
   "{{ .Values.scmType}}-token-key": {{ .Values.crToken | b64enc | quote }}
@@ -72,7 +72,7 @@ data:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: snyk-token
+  name: snyk-token-{{ .Release.Name }}
 type: Opaque
 data:
   "snyk-token-key": {{ .Values.snykToken | b64enc | quote }}
@@ -82,7 +82,7 @@ data:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: nexus-base-nexus-url
+  name: nexus-base-nexus-url-{{ .Release.Name }}
 type: Opaque
 data:
   "nexus-base-nexus-url": {{ .Values.baseNexusUrl | b64enc | quote }}
@@ -92,7 +92,7 @@ data:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: nexus-nexus-url
+  name: nexus-nexus-url-{{ .Release.Name }}
 type: Opaque
 data:
   "nexus-nexus-url": {{ .Values.nexusUrl | b64enc | quote }}

--- a/charts/snyk-broker/templates/serviceaccount.yaml
+++ b/charts/snyk-broker/templates/serviceaccount.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "snyk-broker.serviceAccountName" . }}
+  name: {{ include "snyk-broker.serviceAccountName" . }}-{{ .Release.Name }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "snyk-broker.labels" . | nindent 4 }}

--- a/charts/snyk-broker/tests/__snapshot__/broker_deployment_configmap_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/broker_deployment_configmap_test.yaml.snap
@@ -6,21 +6,21 @@ cacert:
       labels:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-1.8.0
-      name: github-com-broker
+        app.kubernetes.io/name: snyk-broker-RELEASE-NAME
+        helm.sh/chart: snyk-broker-2.0.0
+      name: github-com-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
       replicas: 1
       selector:
         matchLabels:
           app.kubernetes.io/instance: RELEASE-NAME
-          app.kubernetes.io/name: snyk-broker
+          app.kubernetes.io/name: snyk-broker-RELEASE-NAME
       template:
         metadata:
           labels:
             app.kubernetes.io/instance: RELEASE-NAME
-            app.kubernetes.io/name: snyk-broker
+            app.kubernetes.io/name: snyk-broker-RELEASE-NAME
         spec:
           containers:
             - env:
@@ -34,12 +34,12 @@ cacert:
                   valueFrom:
                     secretKeyRef:
                       key: github-com-broker-token-key
-                      name: github-com-broker-token
+                      name: github-com-broker-token-RELEASE-NAME
                 - name: GITHUB_TOKEN
                   valueFrom:
                     secretKeyRef:
                       key: github-com-token-key
-                      name: github-com-token
+                      name: github-com-token-RELEASE-NAME
                 - name: PORT
                   value: "8000"
                 - name: BROKER_CLIENT_URL
@@ -66,7 +66,7 @@ cacert:
                 initialDelaySeconds: 3
                 periodSeconds: 10
                 timeoutSeconds: 1
-              name: github-com-broker
+              name: github-com-broker-RELEASE-NAME
               ports:
                 - containerPort: 8000
                   name: http
@@ -98,10 +98,10 @@ cacert:
                   name: RELEASE-NAME-snyk-broker-cacert-volume
                   readOnly: true
           securityContext: {}
-          serviceAccountName: snyk-broker
+          serviceAccountName: snyk-broker-RELEASE-NAME
           volumes:
             - configMap:
-                name: RELEASE-NAME-snyk-broker-cacert-configmap
+                name: RELEASE-NAME-snyk-broker-cacert-configmap-RELEASE-NAME
               name: RELEASE-NAME-snyk-broker-cacert-volume
   2: |
     apiVersion: v1
@@ -110,9 +110,9 @@ cacert:
       labels:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-1.8.0
-      name: github-com-broker-service
+        app.kubernetes.io/name: snyk-broker-RELEASE-NAME
+        helm.sh/chart: snyk-broker-2.0.0
+      name: github-com-broker-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:
       ports:
@@ -120,7 +120,7 @@ cacert:
           targetPort: 8000
       selector:
         app.kubernetes.io/instance: RELEASE-NAME
-        app.kubernetes.io/name: snyk-broker
+        app.kubernetes.io/name: snyk-broker-RELEASE-NAME
       type: ClusterIP
   3: |
     apiVersion: v1
@@ -152,9 +152,9 @@ cacert:
       labels:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-1.8.0
-      name: RELEASE-NAME-snyk-broker-cacert-configmap
+        app.kubernetes.io/name: snyk-broker-RELEASE-NAME
+        helm.sh/chart: snyk-broker-2.0.0
+      name: RELEASE-NAME-snyk-broker-cacert-configmap-RELEASE-NAME
       namespace: NAMESPACE
   4: |
     apiVersion: v1
@@ -162,7 +162,7 @@ cacert:
       github-com-broker-token-key: MTIz
     kind: Secret
     metadata:
-      name: github-com-broker-token
+      name: github-com-broker-token-RELEASE-NAME
     type: Opaque
   5: |
     apiVersion: v1
@@ -171,9 +171,9 @@ cacert:
       labels:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-1.8.0
-      name: snyk-broker
+        app.kubernetes.io/name: snyk-broker-RELEASE-NAME
+        helm.sh/chart: snyk-broker-2.0.0
+      name: snyk-broker-RELEASE-NAME
       namespace: NAMESPACE
 cacertfile:
   1: |
@@ -183,21 +183,21 @@ cacertfile:
       labels:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-1.8.0
-      name: github-com-broker
+        app.kubernetes.io/name: snyk-broker-RELEASE-NAME
+        helm.sh/chart: snyk-broker-2.0.0
+      name: github-com-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
       replicas: 1
       selector:
         matchLabels:
           app.kubernetes.io/instance: RELEASE-NAME
-          app.kubernetes.io/name: snyk-broker
+          app.kubernetes.io/name: snyk-broker-RELEASE-NAME
       template:
         metadata:
           labels:
             app.kubernetes.io/instance: RELEASE-NAME
-            app.kubernetes.io/name: snyk-broker
+            app.kubernetes.io/name: snyk-broker-RELEASE-NAME
         spec:
           containers:
             - env:
@@ -211,12 +211,12 @@ cacertfile:
                   valueFrom:
                     secretKeyRef:
                       key: github-com-broker-token-key
-                      name: github-com-broker-token
+                      name: github-com-broker-token-RELEASE-NAME
                 - name: GITHUB_TOKEN
                   valueFrom:
                     secretKeyRef:
                       key: github-com-token-key
-                      name: github-com-token
+                      name: github-com-token-RELEASE-NAME
                 - name: PORT
                   value: "8000"
                 - name: BROKER_CLIENT_URL
@@ -241,7 +241,7 @@ cacertfile:
                 initialDelaySeconds: 3
                 periodSeconds: 10
                 timeoutSeconds: 1
-              name: github-com-broker
+              name: github-com-broker-RELEASE-NAME
               ports:
                 - containerPort: 8000
                   name: http
@@ -270,7 +270,7 @@ cacertfile:
                 runAsUser: 1000
               volumeMounts: null
           securityContext: {}
-          serviceAccountName: snyk-broker
+          serviceAccountName: snyk-broker-RELEASE-NAME
           volumes: null
   2: |
     apiVersion: v1
@@ -279,9 +279,9 @@ cacertfile:
       labels:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-1.8.0
-      name: github-com-broker-service
+        app.kubernetes.io/name: snyk-broker-RELEASE-NAME
+        helm.sh/chart: snyk-broker-2.0.0
+      name: github-com-broker-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:
       ports:
@@ -289,7 +289,7 @@ cacertfile:
           targetPort: 8000
       selector:
         app.kubernetes.io/instance: RELEASE-NAME
-        app.kubernetes.io/name: snyk-broker
+        app.kubernetes.io/name: snyk-broker-RELEASE-NAME
       type: ClusterIP
   3: |
     apiVersion: v1
@@ -300,9 +300,9 @@ cacertfile:
       labels:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-1.8.0
-      name: RELEASE-NAME-snyk-broker-cacert-configmap
+        app.kubernetes.io/name: snyk-broker-RELEASE-NAME
+        helm.sh/chart: snyk-broker-2.0.0
+      name: RELEASE-NAME-snyk-broker-cacert-configmap-RELEASE-NAME
       namespace: NAMESPACE
   4: |
     apiVersion: v1
@@ -310,7 +310,7 @@ cacertfile:
       github-com-broker-token-key: MTIz
     kind: Secret
     metadata:
-      name: github-com-broker-token
+      name: github-com-broker-token-RELEASE-NAME
     type: Opaque
   5: |
     apiVersion: v1
@@ -319,7 +319,7 @@ cacertfile:
       labels:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-1.8.0
-      name: snyk-broker
+        app.kubernetes.io/name: snyk-broker-RELEASE-NAME
+        helm.sh/chart: snyk-broker-2.0.0
+      name: snyk-broker-RELEASE-NAME
       namespace: NAMESPACE

--- a/charts/snyk-broker/tests/__snapshot__/broker_deployment_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/broker_deployment_test.yaml.snap
@@ -6,21 +6,21 @@ HA mode on:
       labels:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-1.8.0
-      name: github-com-broker
+        app.kubernetes.io/name: snyk-broker-RELEASE-NAME
+        helm.sh/chart: snyk-broker-2.0.0
+      name: github-com-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
       replicas: 2
       selector:
         matchLabels:
           app.kubernetes.io/instance: RELEASE-NAME
-          app.kubernetes.io/name: snyk-broker
+          app.kubernetes.io/name: snyk-broker-RELEASE-NAME
       template:
         metadata:
           labels:
             app.kubernetes.io/instance: RELEASE-NAME
-            app.kubernetes.io/name: snyk-broker
+            app.kubernetes.io/name: snyk-broker-RELEASE-NAME
         spec:
           containers:
             - env:
@@ -34,12 +34,12 @@ HA mode on:
                   valueFrom:
                     secretKeyRef:
                       key: github-com-broker-token-key
-                      name: github-com-broker-token
+                      name: github-com-broker-token-RELEASE-NAME
                 - name: GITHUB_TOKEN
                   valueFrom:
                     secretKeyRef:
                       key: github-com-token-key
-                      name: github-com-token
+                      name: github-com-token-RELEASE-NAME
                 - name: PORT
                   value: "8000"
                 - name: BROKER_CLIENT_URL
@@ -66,7 +66,7 @@ HA mode on:
                 initialDelaySeconds: 3
                 periodSeconds: 10
                 timeoutSeconds: 1
-              name: github-com-broker
+              name: github-com-broker-RELEASE-NAME
               ports:
                 - containerPort: 8000
                   name: http
@@ -95,7 +95,7 @@ HA mode on:
                 runAsUser: 1000
               volumeMounts: null
           securityContext: {}
-          serviceAccountName: snyk-broker
+          serviceAccountName: snyk-broker-RELEASE-NAME
           volumes: null
   2: |
     apiVersion: v1
@@ -104,9 +104,9 @@ HA mode on:
       labels:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-1.8.0
-      name: github-com-broker-service
+        app.kubernetes.io/name: snyk-broker-RELEASE-NAME
+        helm.sh/chart: snyk-broker-2.0.0
+      name: github-com-broker-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:
       ports:
@@ -114,7 +114,7 @@ HA mode on:
           targetPort: 8000
       selector:
         app.kubernetes.io/instance: RELEASE-NAME
-        app.kubernetes.io/name: snyk-broker
+        app.kubernetes.io/name: snyk-broker-RELEASE-NAME
       type: ClusterIP
   3: |
     apiVersion: v1
@@ -122,7 +122,7 @@ HA mode on:
       github-com-broker-token-key: MTIz
     kind: Secret
     metadata:
-      name: github-com-broker-token
+      name: github-com-broker-token-RELEASE-NAME
     type: Opaque
   4: |
     apiVersion: v1
@@ -131,9 +131,9 @@ HA mode on:
       labels:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-1.8.0
-      name: snyk-broker
+        app.kubernetes.io/name: snyk-broker-RELEASE-NAME
+        helm.sh/chart: snyk-broker-2.0.0
+      name: snyk-broker-RELEASE-NAME
       namespace: NAMESPACE
 HA mode on with 4 replicas:
   1: |
@@ -143,21 +143,21 @@ HA mode on with 4 replicas:
       labels:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-1.8.0
-      name: github-com-broker
+        app.kubernetes.io/name: snyk-broker-RELEASE-NAME
+        helm.sh/chart: snyk-broker-2.0.0
+      name: github-com-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
       replicas: 4
       selector:
         matchLabels:
           app.kubernetes.io/instance: RELEASE-NAME
-          app.kubernetes.io/name: snyk-broker
+          app.kubernetes.io/name: snyk-broker-RELEASE-NAME
       template:
         metadata:
           labels:
             app.kubernetes.io/instance: RELEASE-NAME
-            app.kubernetes.io/name: snyk-broker
+            app.kubernetes.io/name: snyk-broker-RELEASE-NAME
         spec:
           containers:
             - env:
@@ -171,12 +171,12 @@ HA mode on with 4 replicas:
                   valueFrom:
                     secretKeyRef:
                       key: github-com-broker-token-key
-                      name: github-com-broker-token
+                      name: github-com-broker-token-RELEASE-NAME
                 - name: GITHUB_TOKEN
                   valueFrom:
                     secretKeyRef:
                       key: github-com-token-key
-                      name: github-com-token
+                      name: github-com-token-RELEASE-NAME
                 - name: PORT
                   value: "8000"
                 - name: BROKER_CLIENT_URL
@@ -203,7 +203,7 @@ HA mode on with 4 replicas:
                 initialDelaySeconds: 3
                 periodSeconds: 10
                 timeoutSeconds: 1
-              name: github-com-broker
+              name: github-com-broker-RELEASE-NAME
               ports:
                 - containerPort: 8000
                   name: http
@@ -232,7 +232,7 @@ HA mode on with 4 replicas:
                 runAsUser: 1000
               volumeMounts: null
           securityContext: {}
-          serviceAccountName: snyk-broker
+          serviceAccountName: snyk-broker-RELEASE-NAME
           volumes: null
   2: |
     apiVersion: v1
@@ -241,9 +241,9 @@ HA mode on with 4 replicas:
       labels:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-1.8.0
-      name: github-com-broker-service
+        app.kubernetes.io/name: snyk-broker-RELEASE-NAME
+        helm.sh/chart: snyk-broker-2.0.0
+      name: github-com-broker-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:
       ports:
@@ -251,7 +251,7 @@ HA mode on with 4 replicas:
           targetPort: 8000
       selector:
         app.kubernetes.io/instance: RELEASE-NAME
-        app.kubernetes.io/name: snyk-broker
+        app.kubernetes.io/name: snyk-broker-RELEASE-NAME
       type: ClusterIP
   3: |
     apiVersion: v1
@@ -259,7 +259,7 @@ HA mode on with 4 replicas:
       github-com-broker-token-key: MTIz
     kind: Secret
     metadata:
-      name: github-com-broker-token
+      name: github-com-broker-token-RELEASE-NAME
     type: Opaque
   4: |
     apiVersion: v1
@@ -268,9 +268,9 @@ HA mode on with 4 replicas:
       labels:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-1.8.0
-      name: snyk-broker
+        app.kubernetes.io/name: snyk-broker-RELEASE-NAME
+        helm.sh/chart: snyk-broker-2.0.0
+      name: snyk-broker-RELEASE-NAME
       namespace: NAMESPACE
 default values:
   1: |
@@ -280,21 +280,21 @@ default values:
       labels:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-1.8.0
-      name: github-com-broker
+        app.kubernetes.io/name: snyk-broker-RELEASE-NAME
+        helm.sh/chart: snyk-broker-2.0.0
+      name: github-com-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
       replicas: 1
       selector:
         matchLabels:
           app.kubernetes.io/instance: RELEASE-NAME
-          app.kubernetes.io/name: snyk-broker
+          app.kubernetes.io/name: snyk-broker-RELEASE-NAME
       template:
         metadata:
           labels:
             app.kubernetes.io/instance: RELEASE-NAME
-            app.kubernetes.io/name: snyk-broker
+            app.kubernetes.io/name: snyk-broker-RELEASE-NAME
         spec:
           containers:
             - env:
@@ -308,12 +308,12 @@ default values:
                   valueFrom:
                     secretKeyRef:
                       key: github-com-broker-token-key
-                      name: github-com-broker-token
+                      name: github-com-broker-token-RELEASE-NAME
                 - name: GITHUB_TOKEN
                   valueFrom:
                     secretKeyRef:
                       key: github-com-token-key
-                      name: github-com-token
+                      name: github-com-token-RELEASE-NAME
                 - name: PORT
                   value: "8000"
                 - name: BROKER_CLIENT_URL
@@ -338,7 +338,7 @@ default values:
                 initialDelaySeconds: 3
                 periodSeconds: 10
                 timeoutSeconds: 1
-              name: github-com-broker
+              name: github-com-broker-RELEASE-NAME
               ports:
                 - containerPort: 8000
                   name: http
@@ -367,7 +367,7 @@ default values:
                 runAsUser: 1000
               volumeMounts: null
           securityContext: {}
-          serviceAccountName: snyk-broker
+          serviceAccountName: snyk-broker-RELEASE-NAME
           volumes: null
   2: |
     apiVersion: v1
@@ -376,9 +376,9 @@ default values:
       labels:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-1.8.0
-      name: github-com-broker-service
+        app.kubernetes.io/name: snyk-broker-RELEASE-NAME
+        helm.sh/chart: snyk-broker-2.0.0
+      name: github-com-broker-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:
       ports:
@@ -386,7 +386,7 @@ default values:
           targetPort: 8000
       selector:
         app.kubernetes.io/instance: RELEASE-NAME
-        app.kubernetes.io/name: snyk-broker
+        app.kubernetes.io/name: snyk-broker-RELEASE-NAME
       type: ClusterIP
   3: |
     apiVersion: v1
@@ -394,7 +394,7 @@ default values:
       github-com-broker-token-key: MTIz
     kind: Secret
     metadata:
-      name: github-com-broker-token
+      name: github-com-broker-token-RELEASE-NAME
     type: Opaque
   4: |
     apiVersion: v1
@@ -403,9 +403,9 @@ default values:
       labels:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-1.8.0
-      name: snyk-broker
+        app.kubernetes.io/name: snyk-broker-RELEASE-NAME
+        helm.sh/chart: snyk-broker-2.0.0
+      name: snyk-broker-RELEASE-NAME
       namespace: NAMESPACE
 preflight checks off:
   1: |
@@ -415,21 +415,21 @@ preflight checks off:
       labels:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-1.8.0
-      name: github-com-broker
+        app.kubernetes.io/name: snyk-broker-RELEASE-NAME
+        helm.sh/chart: snyk-broker-2.0.0
+      name: github-com-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
       replicas: 1
       selector:
         matchLabels:
           app.kubernetes.io/instance: RELEASE-NAME
-          app.kubernetes.io/name: snyk-broker
+          app.kubernetes.io/name: snyk-broker-RELEASE-NAME
       template:
         metadata:
           labels:
             app.kubernetes.io/instance: RELEASE-NAME
-            app.kubernetes.io/name: snyk-broker
+            app.kubernetes.io/name: snyk-broker-RELEASE-NAME
         spec:
           containers:
             - env:
@@ -443,12 +443,12 @@ preflight checks off:
                   valueFrom:
                     secretKeyRef:
                       key: github-com-broker-token-key
-                      name: github-com-broker-token
+                      name: github-com-broker-token-RELEASE-NAME
                 - name: GITHUB_TOKEN
                   valueFrom:
                     secretKeyRef:
                       key: github-com-token-key
-                      name: github-com-token
+                      name: github-com-token-RELEASE-NAME
                 - name: PORT
                   value: "8000"
                 - name: BROKER_CLIENT_URL
@@ -475,7 +475,7 @@ preflight checks off:
                 initialDelaySeconds: 3
                 periodSeconds: 10
                 timeoutSeconds: 1
-              name: github-com-broker
+              name: github-com-broker-RELEASE-NAME
               ports:
                 - containerPort: 8000
                   name: http
@@ -504,7 +504,7 @@ preflight checks off:
                 runAsUser: 1000
               volumeMounts: null
           securityContext: {}
-          serviceAccountName: snyk-broker
+          serviceAccountName: snyk-broker-RELEASE-NAME
           volumes: null
   2: |
     apiVersion: v1
@@ -513,9 +513,9 @@ preflight checks off:
       labels:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-1.8.0
-      name: github-com-broker-service
+        app.kubernetes.io/name: snyk-broker-RELEASE-NAME
+        helm.sh/chart: snyk-broker-2.0.0
+      name: github-com-broker-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:
       ports:
@@ -523,7 +523,7 @@ preflight checks off:
           targetPort: 8000
       selector:
         app.kubernetes.io/instance: RELEASE-NAME
-        app.kubernetes.io/name: snyk-broker
+        app.kubernetes.io/name: snyk-broker-RELEASE-NAME
       type: ClusterIP
   3: |
     apiVersion: v1
@@ -531,7 +531,7 @@ preflight checks off:
       github-com-broker-token-key: MTIz
     kind: Secret
     metadata:
-      name: github-com-broker-token
+      name: github-com-broker-token-RELEASE-NAME
     type: Opaque
   4: |
     apiVersion: v1
@@ -540,7 +540,7 @@ preflight checks off:
       labels:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-1.8.0
-      name: snyk-broker
+        app.kubernetes.io/name: snyk-broker-RELEASE-NAME
+        helm.sh/chart: snyk-broker-2.0.0
+      name: snyk-broker-RELEASE-NAME
       namespace: NAMESPACE


### PR DESCRIPTION
By naming each object with the release name, we now have the ability to "name" broker deployments and surrounding object to be unique inside a namespace.

`helm install broker-1 snyk-broker/snyk-broker --set scmType=..... --set XYZ....` will create object suffixed -broker-1, allowing you to run a second `helm install broker-2....` inside the same namespace.