### PR TITLE
feat: add support for using dev images

### DIFF
--- a/charts/snyk-broker/templates/broker_deployment.yaml
+++ b/charts/snyk-broker/templates/broker_deployment.yaml
@@ -46,6 +46,8 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           {{- if .Values.image.tag }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}-{{ .Values.scmType }}"
+          {{- else if eq .Values.image.tag "dev" }}
+          image: "{{ .Values.image.repository }}:{{ .Values.scmType }}-{{ .Values.image.tag }}"
           {{- else }}
           image: "{{ .Values.image.repository }}:{{ .Values.scmType }}"
           {{- end }}


### PR DESCRIPTION
Snyk have started publishing [dev images to their Docker repository](https://hub.docker.com/r/snyk/broker/tags?page=1&name=dev). However, the current broker deployment template doesn't account for the fact that Snyk have chosen to tag these releases with the SCM type being the prefix rather than the suffix.