### PR TITLE
fix: DRA helm chart installs failing

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,6 @@
 * @snyk/team-broker
 
+charts/snyk-broker/templates/cra_deployment.yaml @snyk/container-integration
+charts/snyk-broker/tests/broker_cra_deployment_test.yaml @snyk/container-integration
+charts/snyk-broker/tests/cra_deployment_test.yaml @snyk/container-integration
+charts/snyk-broker/tests/fixtures/default_values_cra.yaml @snyk/container-integration

--- a/charts/snyk-broker/Chart.yaml
+++ b/charts/snyk-broker/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: snyk-broker
-version: 2.0.1
+version: 2.0.2
 description: A Helm chart for Kubernetes
 type: application

--- a/charts/snyk-broker/templates/broker_deployment.yaml
+++ b/charts/snyk-broker/templates/broker_deployment.yaml
@@ -270,7 +270,7 @@ spec:
                   name: {{ .Values.scmType}}-broker-token-{{ .Release.Name }}
                   key: "{{ .Values.scmType}}-broker-token-key"
             - name: CR_AGENT_URL
-              value: http://cra-service:{{ .Values.deployment.container.crSnykPort | toString }}
+              value: http://cra-service-{{ .Release.Name }}:{{ .Values.deployment.container.crSnykPort | toString }}
             - name: CR_TYPE
               value: {{ .Values.crType }}
             - name: CR_BASE
@@ -298,7 +298,7 @@ spec:
             - name: BROKER_CLIENT_URL
               value: {{ .Values.brokerClientUrl }}
             - name: BROKER_CLIENT_VALIDATION_URL
-              value: http://cra-service:{{ .Values.deployment.container.crSnykPort | toString }}/healthcheck
+              value: http://cra-service-{{ .Release.Name }}:{{ .Values.deployment.container.crSnykPort | toString }}/healthcheck
           {{- end }}
          {{- if .Values.enableCodeAgent }}
          # Code Agent

--- a/charts/snyk-broker/templates/cra_deployment.yaml
+++ b/charts/snyk-broker/templates/cra_deployment.yaml
@@ -29,7 +29,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      serviceAccountName: {{ include "snyk-broker.serviceAccountName" . }}
+      serviceAccountName: {{ include "snyk-broker.serviceAccountName" . }}-{{ .Release.Name }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
@@ -77,6 +77,6 @@ spec:
     - port: {{ .Values.deployment.container.crSnykPort }}
       targetPort: {{ .Values.deployment.container.crSnykPort}}
   selector:
-    app.kubernetes.io/name: {{ .Release.Name }}-cr
+    app.kubernetes.io/name: {{ .Release.Name }}-cr-{{ .Release.Name }}
     app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}

--- a/charts/snyk-broker/tests/__snapshot__/broker_cra_deployment_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/broker_cra_deployment_test.yaml.snap
@@ -1,4 +1,4 @@
-ingress:
+with CRA:
   1: |
     apiVersion: apps/v1
     kind: Deployment
@@ -8,7 +8,7 @@ ingress:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
         helm.sh/chart: snyk-broker-2.0.2
-      name: github-com-broker-RELEASE-NAME
+      name: container-registry-agent-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
       replicas: 1
@@ -33,28 +33,45 @@ ingress:
                 - name: BROKER_TOKEN
                   valueFrom:
                     secretKeyRef:
-                      key: github-com-broker-token-key
-                      name: github-com-broker-token-RELEASE-NAME
-                - name: GITHUB_TOKEN
+                      key: container-registry-agent-broker-token-key
+                      name: container-registry-agent-broker-token-RELEASE-NAME
+                - name: CR_AGENT_URL
+                  value: http://cra-service-RELEASE-NAME:8081
+                - name: CR_TYPE
+                  value: null
+                - name: CR_BASE
+                  value: null
+                - name: CR_USERNAME
+                  value: null
+                - name: CR_PASSWORD
                   valueFrom:
                     secretKeyRef:
-                      key: github-com-token-key
-                      name: github-com-token-RELEASE-NAME
+                      key: container-registry-agent-token-key
+                      name: container-registry-agent-token-RELEASE-NAME
+                - name: CR_TOKEN
+                  valueFrom:
+                    secretKeyRef:
+                      key: container-registry-agent-token-key
+                      name: container-registry-agent-token-RELEASE-NAME
+                - name: CR_ROLE_ARN
+                  value: arn:aws-us-gov:iam::123456789012:role
+                - name: CR_REGION
+                  value: eu-west
+                - name: CR_EXTERNAL_ID
+                  value: 11111111-1111-1111-1111-111111111111
                 - name: PORT
                   value: "8000"
                 - name: BROKER_CLIENT_URL
                   value: http://brokerclient
+                - name: BROKER_CLIENT_VALIDATION_URL
+                  value: http://cra-service-RELEASE-NAME:8081/healthcheck
                 - name: LOG_LEVEL
                   value: info
                 - name: LOG_ENABLE_BODY
                   value: "false"
-                - name: ACCEPT_CODE
-                  value: "true"
-                - name: ACCEPT_IAC
-                  value: tf,yaml,yml,json,tpl
                 - name: BROKER_DISPATCHER_BASE_URL
                   value: https://api.test.snyk.io
-              image: snyk/broker:github-com
+              image: snyk/broker:container-registry-agent
               imagePullPolicy: Always
               livenessProbe:
                 failureThreshold: 3
@@ -64,7 +81,7 @@ ingress:
                 initialDelaySeconds: 3
                 periodSeconds: 10
                 timeoutSeconds: 1
-              name: github-com-broker-RELEASE-NAME
+              name: container-registry-agent-broker-RELEASE-NAME
               ports:
                 - containerPort: 8000
                   name: http
@@ -96,26 +113,6 @@ ingress:
           serviceAccountName: snyk-broker-RELEASE-NAME
           volumes: null
   2: |
-    apiVersion: extensions/v1beta1
-    kind: Ingress
-    metadata:
-      labels:
-        app.kubernetes.io/instance: RELEASE-NAME
-        app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.0.2
-      name: RELEASE-NAME-snyk-broker-RELEASE-NAME
-      namespace: NAMESPACE
-    spec:
-      rules:
-        - host: <ENTER_BROKER_CLIENT_URL>
-          http:
-            paths:
-              - backend:
-                  serviceName: github-com-broker-service-RELEASE-NAME
-                  servicePort: 8000
-                path: /
-  3: |
     apiVersion: v1
     kind: Service
     metadata:
@@ -124,7 +121,7 @@ ingress:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
         helm.sh/chart: snyk-broker-2.0.2
-      name: github-com-broker-service-RELEASE-NAME
+      name: container-registry-agent-broker-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:
       ports:
@@ -134,15 +131,15 @@ ingress:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
       type: ClusterIP
-  4: |
+  3: |
     apiVersion: v1
     data:
-      github-com-broker-token-key: MTIz
+      container-registry-agent-broker-token-key: MTIz
     kind: Secret
     metadata:
-      name: github-com-broker-token-RELEASE-NAME
+      name: container-registry-agent-broker-token-RELEASE-NAME
     type: Opaque
-  5: |
+  4: |
     apiVersion: v1
     kind: ServiceAccount
     metadata:

--- a/charts/snyk-broker/tests/__snapshot__/broker_deployment_configmap_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/broker_deployment_configmap_test.yaml.snap
@@ -7,7 +7,7 @@ cacert:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.0.1
+        helm.sh/chart: snyk-broker-2.0.2
       name: github-com-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -111,7 +111,7 @@ cacert:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.0.1
+        helm.sh/chart: snyk-broker-2.0.2
       name: github-com-broker-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -153,7 +153,7 @@ cacert:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.0.1
+        helm.sh/chart: snyk-broker-2.0.2
       name: RELEASE-NAME-snyk-broker-cacert-configmap-RELEASE-NAME
       namespace: NAMESPACE
   4: |
@@ -172,7 +172,7 @@ cacert:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.0.1
+        helm.sh/chart: snyk-broker-2.0.2
       name: snyk-broker-RELEASE-NAME
       namespace: NAMESPACE
 cacertfile:
@@ -184,7 +184,7 @@ cacertfile:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.0.1
+        helm.sh/chart: snyk-broker-2.0.2
       name: github-com-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -280,7 +280,7 @@ cacertfile:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.0.1
+        helm.sh/chart: snyk-broker-2.0.2
       name: github-com-broker-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -301,7 +301,7 @@ cacertfile:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.0.1
+        helm.sh/chart: snyk-broker-2.0.2
       name: RELEASE-NAME-snyk-broker-cacert-configmap-RELEASE-NAME
       namespace: NAMESPACE
   4: |
@@ -320,6 +320,6 @@ cacertfile:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.0.1
+        helm.sh/chart: snyk-broker-2.0.2
       name: snyk-broker-RELEASE-NAME
       namespace: NAMESPACE

--- a/charts/snyk-broker/tests/__snapshot__/broker_deployment_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/broker_deployment_test.yaml.snap
@@ -7,7 +7,7 @@ HA mode on:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.0.1
+        helm.sh/chart: snyk-broker-2.0.2
       name: github-com-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -105,7 +105,7 @@ HA mode on:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.0.1
+        helm.sh/chart: snyk-broker-2.0.2
       name: github-com-broker-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -132,7 +132,7 @@ HA mode on:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.0.1
+        helm.sh/chart: snyk-broker-2.0.2
       name: snyk-broker-RELEASE-NAME
       namespace: NAMESPACE
 HA mode on with 4 replicas:
@@ -144,7 +144,7 @@ HA mode on with 4 replicas:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.0.1
+        helm.sh/chart: snyk-broker-2.0.2
       name: github-com-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -242,7 +242,7 @@ HA mode on with 4 replicas:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.0.1
+        helm.sh/chart: snyk-broker-2.0.2
       name: github-com-broker-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -269,7 +269,7 @@ HA mode on with 4 replicas:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.0.1
+        helm.sh/chart: snyk-broker-2.0.2
       name: snyk-broker-RELEASE-NAME
       namespace: NAMESPACE
 default values:
@@ -281,7 +281,7 @@ default values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.0.1
+        helm.sh/chart: snyk-broker-2.0.2
       name: github-com-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -377,7 +377,7 @@ default values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.0.1
+        helm.sh/chart: snyk-broker-2.0.2
       name: github-com-broker-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -404,7 +404,7 @@ default values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.0.1
+        helm.sh/chart: snyk-broker-2.0.2
       name: snyk-broker-RELEASE-NAME
       namespace: NAMESPACE
 preflight checks off:
@@ -416,7 +416,7 @@ preflight checks off:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.0.1
+        helm.sh/chart: snyk-broker-2.0.2
       name: github-com-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -514,7 +514,7 @@ preflight checks off:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.0.1
+        helm.sh/chart: snyk-broker-2.0.2
       name: github-com-broker-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -541,6 +541,6 @@ preflight checks off:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.0.1
+        helm.sh/chart: snyk-broker-2.0.2
       name: snyk-broker-RELEASE-NAME
       namespace: NAMESPACE

--- a/charts/snyk-broker/tests/__snapshot__/cra_deployment_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/cra_deployment_test.yaml.snap
@@ -1,0 +1,68 @@
+default values:
+  1: |
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      labels:
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/name: RELEASE-NAME-cr-RELEASE-NAME
+      name: container-registry-agent-cra-RELEASE-NAME
+      namespace: NAMESPACE
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app.kubernetes.io/instance: RELEASE-NAME
+          app.kubernetes.io/name: RELEASE-NAME-cr-RELEASE-NAME
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/name: RELEASE-NAME-cr-RELEASE-NAME
+        spec:
+          containers:
+            - env:
+                - name: SNYK_PORT
+                  value: "8081"
+              image: snyk/container-registry-agent:latest
+              imagePullPolicy: Always
+              name: container-registry-agent-RELEASE-NAME
+              ports:
+                - containerPort: 8081
+                  name: http
+              resources:
+                limits:
+                  cpu: 1
+                  memory: 2Gi
+                requests:
+                  cpu: 1
+                  memory: 2Gi
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+                readOnlyRootFilesystem: false
+                runAsNonRoot: true
+                runAsUser: 1000
+          securityContext: {}
+          serviceAccountName: snyk-broker-RELEASE-NAME
+  2: |
+    apiVersion: v1
+    kind: Service
+    metadata:
+      labels:
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: snyk-broker-RELEASE-NAME
+        helm.sh/chart: snyk-broker-2.0.2
+      name: cra-service-RELEASE-NAME
+      namespace: NAMESPACE
+    spec:
+      ports:
+        - port: 8081
+          targetPort: 8081
+      selector:
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/name: RELEASE-NAME-cr-RELEASE-NAME
+      type: ClusterIP

--- a/charts/snyk-broker/tests/broker_cra_deployment_test.yaml
+++ b/charts/snyk-broker/tests/broker_cra_deployment_test.yaml
@@ -1,0 +1,13 @@
+suite: test broker deployment
+templates: 
+  - broker_deployment.yaml
+  - broker_service.yaml
+  - secrets.yaml
+  - serviceaccount.yaml
+
+tests:
+  - it: with CRA
+    values:
+      - ./fixtures/default_values_cra.yaml
+    asserts:
+      - matchSnapshot: {}

--- a/charts/snyk-broker/tests/cra_deployment_test.yaml
+++ b/charts/snyk-broker/tests/cra_deployment_test.yaml
@@ -1,0 +1,10 @@
+suite: test broker deployment
+templates: 
+  - cra_deployment.yaml
+
+tests:
+  - it: default values
+    values:
+      - ./fixtures/default_values_cra.yaml
+    asserts:
+      - matchSnapshot: {}

--- a/charts/snyk-broker/tests/fixtures/default_values_cra.yaml
+++ b/charts/snyk-broker/tests/fixtures/default_values_cra.yaml
@@ -1,0 +1,30 @@
+# Default values for snyk-broker with Container Registry Agent.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+##### Snyk Specific Values #####
+
+# Broker Token is a value from Snyk. Get this from the integration settings page or your Snyk Representative
+brokerToken: "123"
+
+# brokerClientUrl is the address of the broker. This needs to be the address of itself. In the case of Kubernetes, you need to ensure that you are pointing to the cluster ingress you have setup.
+# Ex: http://kubernetes-ingress.domain.com:8000/broker
+brokerClientUrl: "http://brokerclient"
+
+# Do not touch unless directed by a Snyk Representative
+brokerServerUrl: "https://broker.test.snyk.io"
+
+preflightChecks:
+  enabled: true
+
+highAvailabilityMode:
+  enabled: false
+brokerDispatcherUrl: "https://api.test.snyk.io"
+
+scmType: "container-registry-agent"
+
+crRoleArn: "arn:aws-us-gov:iam::123456789012:role"
+
+crRegion: "eu-west"
+
+crExternalId: "11111111-1111-1111-1111-111111111111"


### PR DESCRIPTION
### Context
This PR is regarding issues after the changes introduced in [this PR](https://github.com/snyk/snyk-broker-helm/pull/79
).
Issues were reported by the customer in this ticket:
https://snyk.zendesk.com/agent/tickets/58273
and it regards mismatches in the Helm Chart variables which are causing the Helm installation of the brokered CRA to fails.

### What this is doing
I have addressed in this PR <just> the comments from the customer in order to have a starting point for the discussion.
I think such scenarios should be caught by tests.

### Reviewer's note
Would be better to review commit by commit. One of the commits it's adding container-integration as code ownders for the CRA files.
