### PR TITLE
fix: configure broker client service url

### DIFF
--- a/charts/snyk-broker/templates/_helpers.tpl
+++ b/charts/snyk-broker/templates/_helpers.tpl
@@ -99,3 +99,14 @@ Return if ingress supports pathType.
 {{- define "snyk-broker.ingress.supportsPathType" -}}
   {{- or (eq (include "snyk-broker.ingress.isStable" .) "true") (and (eq (include "snyk-broker.ingress.apiVersion" .) "networking.k8s.io/v1beta1") (semverCompare ">= 1.18-0" .Capabilities.KubeVersion.Version)) -}}
 {{- end -}}
+
+{{/*
+Create the name of the broker service to use
+*/}}
+{{- define "snyk-broker.brokerServiceName" -}}
+{{- if not .Values.disableSuffixes -}}
+{{ .Values.scmType }}-broker-service-{{ .Release.Name }}
+{{- else }}
+{{ .Values.scmType}}-broker-service
+{{- end -}}
+{{- end -}}

--- a/charts/snyk-broker/templates/broker_deployment.yaml
+++ b/charts/snyk-broker/templates/broker_deployment.yaml
@@ -315,7 +315,7 @@ spec:
             - name: PORT
               value: {{ .Values.deployment.container.containerPort | squote }}
             - name: BROKER_CLIENT_URL
-              value: {{ .Values.brokerClientUrl }}
+              value: "http://{{ include "snyk-broker.brokerServiceName" . }}:{{ .Values.service.port }}"
             - name: BROKER_CLIENT_VALIDATION_URL
               value: http://cra-service{{if not .Values.disableSuffixes }}-{{ .Release.Name }}{{ end }}:{{ .Values.deployment.container.crSnykPort | toString }}/healthcheck
           {{- end }}

--- a/charts/snyk-broker/templates/broker_ingress.yaml
+++ b/charts/snyk-broker/templates/broker_ingress.yaml
@@ -3,8 +3,8 @@
 {{- $ingressSupportsIngressClassName := eq (include "snyk-broker.ingress.supportsIngressClassName" .) "true" -}}
 {{- $ingressSupportsPathType := eq (include "snyk-broker.ingress.supportsPathType" .) "true" -}}
 {{- $fullName := include "snyk-broker.fullname" . -}}
-{{- $scmType := .Values.scmType -}}
 {{- $servicePort := .Values.service.port -}}
+{{- $scmType := .Values.scmType -}}
 {{- $ingressPath := .Values.brokerIngress.path -}}
 {{- $ingressPathType := .Values.brokerIngress.pathType -}}
 {{- $extraPaths := .Values.brokerIngress.extraPaths -}}
@@ -50,7 +50,7 @@ spec:
             backend:
               {{- if $ingressApiIsStable }}
               service:
-                name: {{ $scmType }}-broker-service{{ if not $disableSuffixes}}-{{ $releaseName }}{{ end }}
+                name: {{ include "snyk-broker.brokerServiceName" $ }}
                 port:
                   number: {{ $servicePort }}
               {{- else }}
@@ -64,11 +64,11 @@ spec:
           - backend:
               {{- if $ingressApiIsStable }}
               service:
-                name: {{ $scmType }}-broker-service{{ if not $disableSuffixes}}-{{ $releaseName }}{{ end }}
+                name: {{ include "snyk-broker.brokerServiceName" . }}
                 port:
                   number: {{ $servicePort }}
               {{- else }}
-              serviceName: {{ $scmType }}-broker-service{{ if not $disableSuffixes}}-{{ $releaseName }}{{ end }}
+              serviceName: {{ include "snyk-broker.brokerServiceName" . }}
               servicePort: {{ $servicePort }}
               {{- end }}
             {{- if $ingressPath }}

--- a/charts/snyk-broker/templates/broker_service.yaml
+++ b/charts/snyk-broker/templates/broker_service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: "{{ .Values.scmType}}-broker-service{{if not .Values.disableSuffixes }}-{{ .Release.Name }}{{ end }}"
+  name: {{ include "snyk-broker.brokerServiceName" . | nindent 4 }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "snyk-broker.labels" . | nindent 4 }}

--- a/charts/snyk-broker/tests/__snapshot__/broker_cra_deployment_disablesuffixes_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/broker_cra_deployment_disablesuffixes_test.yaml.snap
@@ -62,7 +62,7 @@ with CRA:
                 - name: PORT
                   value: "8000"
                 - name: BROKER_CLIENT_URL
-                  value: http://brokerclient
+                  value: http://container-registry-agent-broker-service-RELEASE-NAME:8000
                 - name: BROKER_CLIENT_VALIDATION_URL
                   value: http://cra-service-RELEASE-NAME:8081/healthcheck
                 - name: LOG_LEVEL

--- a/charts/snyk-broker/tests/__snapshot__/broker_cra_deployment_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/broker_cra_deployment_test.yaml.snap
@@ -62,7 +62,7 @@ with CRA:
                 - name: PORT
                   value: "8000"
                 - name: BROKER_CLIENT_URL
-                  value: http://brokerclient
+                  value: http://container-registry-agent-broker-service-RELEASE-NAME:8000
                 - name: BROKER_CLIENT_VALIDATION_URL
                   value: http://cra-service-RELEASE-NAME:8081/healthcheck
                 - name: LOG_LEVEL

--- a/charts/snyk-broker/values.yaml
+++ b/charts/snyk-broker/values.yaml
@@ -24,8 +24,6 @@ brokerDispatcherUrl: "https://api.snyk.io"
 # This number if only used if enableHighAvailabilityMode is true
 replicaCount: 2
 
-
-
 ##### SCM Generic #####
 
 # scmType is used to define the Source Control that you are connecting to. 


### PR DESCRIPTION
Currently, the customer has to specify the name of the broker service. But for CRA this is not needed, since they are running in the same cluster and it's always known.