### PR TITLE
fix: align code-agent secret name to suffix named secret

### DIFF
--- a/charts/snyk-broker/Chart.yaml
+++ b/charts/snyk-broker/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: snyk-broker
-version: 2.2.1
+version: 2.2.2
 description: A Helm chart for Kubernetes
 type: application

--- a/charts/snyk-broker/templates/code_agent_deployment.yaml
+++ b/charts/snyk-broker/templates/code_agent_deployment.yaml
@@ -58,7 +58,7 @@ spec:
             - name: SNYK_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: snyk-token
+                  name: snyk-token{{if not .Values.disableSuffixes }}-{{ .Release.Name }}{{ end }}
                   key: snyk-token-key
          {{- if .Values.tlsRejectUnauthorized  }}
          # Troubleshooting - Set to 0 for SSL inspection testing

--- a/charts/snyk-broker/tests/__snapshot__/broker_cra_deployment_disablesuffixes_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/broker_cra_deployment_disablesuffixes_test.yaml.snap
@@ -7,7 +7,7 @@ with CRA:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.2.1
+        helm.sh/chart: snyk-broker-2.2.2
       name: container-registry-agent-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -120,7 +120,7 @@ with CRA:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.2.1
+        helm.sh/chart: snyk-broker-2.2.2
       name: container-registry-agent-broker-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -147,6 +147,6 @@ with CRA:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.2.1
+        helm.sh/chart: snyk-broker-2.2.2
       name: snyk-broker-RELEASE-NAME
       namespace: NAMESPACE

--- a/charts/snyk-broker/tests/__snapshot__/broker_cra_deployment_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/broker_cra_deployment_test.yaml.snap
@@ -7,7 +7,7 @@ with CRA:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.2.1
+        helm.sh/chart: snyk-broker-2.2.2
       name: container-registry-agent-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -120,7 +120,7 @@ with CRA:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.2.1
+        helm.sh/chart: snyk-broker-2.2.2
       name: container-registry-agent-broker-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -147,6 +147,6 @@ with CRA:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.2.1
+        helm.sh/chart: snyk-broker-2.2.2
       name: snyk-broker-RELEASE-NAME
       namespace: NAMESPACE

--- a/charts/snyk-broker/tests/__snapshot__/broker_deployment_configmap_disablesuffixes_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/broker_deployment_configmap_disablesuffixes_test.yaml.snap
@@ -7,7 +7,7 @@ cacert:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.2.1
+        helm.sh/chart: snyk-broker-2.2.2
       name: github-com-broker
       namespace: NAMESPACE
     spec:
@@ -113,7 +113,7 @@ cacert:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.2.1
+        helm.sh/chart: snyk-broker-2.2.2
       name: github-com-broker-service
       namespace: NAMESPACE
     spec:
@@ -155,7 +155,7 @@ cacert:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.2.1
+        helm.sh/chart: snyk-broker-2.2.2
       name: RELEASE-NAME-snyk-broker-cacert-configmap
       namespace: NAMESPACE
   4: |
@@ -174,7 +174,7 @@ cacert:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.2.1
+        helm.sh/chart: snyk-broker-2.2.2
       name: snyk-broker
       namespace: NAMESPACE
 cacertfile:
@@ -186,7 +186,7 @@ cacertfile:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.2.1
+        helm.sh/chart: snyk-broker-2.2.2
       name: github-com-broker
       namespace: NAMESPACE
     spec:
@@ -282,7 +282,7 @@ cacertfile:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.2.1
+        helm.sh/chart: snyk-broker-2.2.2
       name: github-com-broker-service
       namespace: NAMESPACE
     spec:
@@ -303,7 +303,7 @@ cacertfile:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.2.1
+        helm.sh/chart: snyk-broker-2.2.2
       name: RELEASE-NAME-snyk-broker-cacert-configmap
       namespace: NAMESPACE
   4: |
@@ -322,6 +322,6 @@ cacertfile:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.2.1
+        helm.sh/chart: snyk-broker-2.2.2
       name: snyk-broker
       namespace: NAMESPACE

--- a/charts/snyk-broker/tests/__snapshot__/broker_deployment_configmap_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/broker_deployment_configmap_test.yaml.snap
@@ -7,7 +7,7 @@ cacert:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.2.1
+        helm.sh/chart: snyk-broker-2.2.2
       name: github-com-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -113,7 +113,7 @@ cacert:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.2.1
+        helm.sh/chart: snyk-broker-2.2.2
       name: github-com-broker-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -155,7 +155,7 @@ cacert:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.2.1
+        helm.sh/chart: snyk-broker-2.2.2
       name: RELEASE-NAME-snyk-broker-cacert-configmap-RELEASE-NAME
       namespace: NAMESPACE
   4: |
@@ -174,7 +174,7 @@ cacert:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.2.1
+        helm.sh/chart: snyk-broker-2.2.2
       name: snyk-broker-RELEASE-NAME
       namespace: NAMESPACE
 cacertfile:
@@ -186,7 +186,7 @@ cacertfile:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.2.1
+        helm.sh/chart: snyk-broker-2.2.2
       name: github-com-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -282,7 +282,7 @@ cacertfile:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.2.1
+        helm.sh/chart: snyk-broker-2.2.2
       name: github-com-broker-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -303,7 +303,7 @@ cacertfile:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.2.1
+        helm.sh/chart: snyk-broker-2.2.2
       name: RELEASE-NAME-snyk-broker-cacert-configmap-RELEASE-NAME
       namespace: NAMESPACE
   4: |
@@ -322,6 +322,6 @@ cacertfile:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.2.1
+        helm.sh/chart: snyk-broker-2.2.2
       name: snyk-broker-RELEASE-NAME
       namespace: NAMESPACE

--- a/charts/snyk-broker/tests/__snapshot__/broker_deployment_customaccept_disablesuffixes_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/broker_deployment_customaccept_disablesuffixes_test.yaml.snap
@@ -9,7 +9,7 @@ customaccept values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.2.1
+        helm.sh/chart: snyk-broker-2.2.2
       name: RELEASE-NAME-snyk-broker-accept-configmap
       namespace: NAMESPACE
   2: |
@@ -20,7 +20,7 @@ customaccept values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.2.1
+        helm.sh/chart: snyk-broker-2.2.2
       name: github-com-broker
       namespace: NAMESPACE
     spec:
@@ -120,7 +120,7 @@ customaccept values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.2.1
+        helm.sh/chart: snyk-broker-2.2.2
       name: github-com-broker-service
       namespace: NAMESPACE
     spec:
@@ -147,6 +147,6 @@ customaccept values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.2.1
+        helm.sh/chart: snyk-broker-2.2.2
       name: snyk-broker
       namespace: NAMESPACE

--- a/charts/snyk-broker/tests/__snapshot__/broker_deployment_customaccept_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/broker_deployment_customaccept_test.yaml.snap
@@ -9,7 +9,7 @@ customaccept values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.2.1
+        helm.sh/chart: snyk-broker-2.2.2
       name: RELEASE-NAME-snyk-broker-accept-configmap-RELEASE-NAME
       namespace: NAMESPACE
   2: |
@@ -20,7 +20,7 @@ customaccept values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.2.1
+        helm.sh/chart: snyk-broker-2.2.2
       name: github-com-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -120,7 +120,7 @@ customaccept values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.2.1
+        helm.sh/chart: snyk-broker-2.2.2
       name: github-com-broker-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -147,6 +147,6 @@ customaccept values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.2.1
+        helm.sh/chart: snyk-broker-2.2.2
       name: snyk-broker-RELEASE-NAME
       namespace: NAMESPACE

--- a/charts/snyk-broker/tests/__snapshot__/broker_deployment_disablesuffixes_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/broker_deployment_disablesuffixes_test.yaml.snap
@@ -7,7 +7,7 @@ HA mode on:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.2.1
+        helm.sh/chart: snyk-broker-2.2.2
       name: github-com-broker
       namespace: NAMESPACE
     spec:
@@ -105,7 +105,7 @@ HA mode on:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.2.1
+        helm.sh/chart: snyk-broker-2.2.2
       name: github-com-broker-service
       namespace: NAMESPACE
     spec:
@@ -132,7 +132,7 @@ HA mode on:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.2.1
+        helm.sh/chart: snyk-broker-2.2.2
       name: snyk-broker
       namespace: NAMESPACE
 HA mode on with 4 replicas:
@@ -144,7 +144,7 @@ HA mode on with 4 replicas:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.2.1
+        helm.sh/chart: snyk-broker-2.2.2
       name: github-com-broker
       namespace: NAMESPACE
     spec:
@@ -242,7 +242,7 @@ HA mode on with 4 replicas:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.2.1
+        helm.sh/chart: snyk-broker-2.2.2
       name: github-com-broker-service
       namespace: NAMESPACE
     spec:
@@ -269,7 +269,7 @@ HA mode on with 4 replicas:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.2.1
+        helm.sh/chart: snyk-broker-2.2.2
       name: snyk-broker
       namespace: NAMESPACE
 default values:
@@ -281,7 +281,7 @@ default values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.2.1
+        helm.sh/chart: snyk-broker-2.2.2
       name: github-com-broker
       namespace: NAMESPACE
     spec:
@@ -377,7 +377,7 @@ default values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.2.1
+        helm.sh/chart: snyk-broker-2.2.2
       name: github-com-broker-service
       namespace: NAMESPACE
     spec:
@@ -404,7 +404,7 @@ default values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.2.1
+        helm.sh/chart: snyk-broker-2.2.2
       name: snyk-broker
       namespace: NAMESPACE
 preflight checks off:
@@ -416,7 +416,7 @@ preflight checks off:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.2.1
+        helm.sh/chart: snyk-broker-2.2.2
       name: github-com-broker
       namespace: NAMESPACE
     spec:
@@ -514,7 +514,7 @@ preflight checks off:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.2.1
+        helm.sh/chart: snyk-broker-2.2.2
       name: github-com-broker-service
       namespace: NAMESPACE
     spec:
@@ -541,6 +541,6 @@ preflight checks off:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.2.1
+        helm.sh/chart: snyk-broker-2.2.2
       name: snyk-broker
       namespace: NAMESPACE

--- a/charts/snyk-broker/tests/__snapshot__/broker_deployment_ingress_disablesuffixes_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/broker_deployment_ingress_disablesuffixes_test.yaml.snap
@@ -7,7 +7,7 @@ ingress:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.2.1
+        helm.sh/chart: snyk-broker-2.2.2
       name: github-com-broker
       namespace: NAMESPACE
     spec:
@@ -103,7 +103,7 @@ ingress:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.2.1
+        helm.sh/chart: snyk-broker-2.2.2
       name: RELEASE-NAME-snyk-broker
       namespace: NAMESPACE
     spec:
@@ -123,7 +123,7 @@ ingress:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.2.1
+        helm.sh/chart: snyk-broker-2.2.2
       name: github-com-broker-service
       namespace: NAMESPACE
     spec:
@@ -150,6 +150,6 @@ ingress:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.2.1
+        helm.sh/chart: snyk-broker-2.2.2
       name: snyk-broker
       namespace: NAMESPACE

--- a/charts/snyk-broker/tests/__snapshot__/broker_deployment_ingress_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/broker_deployment_ingress_test.yaml.snap
@@ -7,7 +7,7 @@ ingress:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.2.1
+        helm.sh/chart: snyk-broker-2.2.2
       name: github-com-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -103,7 +103,7 @@ ingress:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.2.1
+        helm.sh/chart: snyk-broker-2.2.2
       name: RELEASE-NAME-snyk-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -123,7 +123,7 @@ ingress:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.2.1
+        helm.sh/chart: snyk-broker-2.2.2
       name: github-com-broker-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -150,6 +150,6 @@ ingress:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.2.1
+        helm.sh/chart: snyk-broker-2.2.2
       name: snyk-broker-RELEASE-NAME
       namespace: NAMESPACE

--- a/charts/snyk-broker/tests/__snapshot__/broker_deployment_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/broker_deployment_test.yaml.snap
@@ -7,7 +7,7 @@ HA mode on:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.2.1
+        helm.sh/chart: snyk-broker-2.2.2
       name: github-com-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -105,7 +105,7 @@ HA mode on:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.2.1
+        helm.sh/chart: snyk-broker-2.2.2
       name: github-com-broker-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -132,7 +132,7 @@ HA mode on:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.2.1
+        helm.sh/chart: snyk-broker-2.2.2
       name: snyk-broker-RELEASE-NAME
       namespace: NAMESPACE
 HA mode on with 4 replicas:
@@ -144,7 +144,7 @@ HA mode on with 4 replicas:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.2.1
+        helm.sh/chart: snyk-broker-2.2.2
       name: github-com-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -242,7 +242,7 @@ HA mode on with 4 replicas:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.2.1
+        helm.sh/chart: snyk-broker-2.2.2
       name: github-com-broker-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -269,7 +269,7 @@ HA mode on with 4 replicas:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.2.1
+        helm.sh/chart: snyk-broker-2.2.2
       name: snyk-broker-RELEASE-NAME
       namespace: NAMESPACE
 default values:
@@ -281,7 +281,7 @@ default values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.2.1
+        helm.sh/chart: snyk-broker-2.2.2
       name: github-com-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -377,7 +377,7 @@ default values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.2.1
+        helm.sh/chart: snyk-broker-2.2.2
       name: github-com-broker-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -404,7 +404,7 @@ default values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.2.1
+        helm.sh/chart: snyk-broker-2.2.2
       name: snyk-broker-RELEASE-NAME
       namespace: NAMESPACE
 preflight checks off:
@@ -416,7 +416,7 @@ preflight checks off:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.2.1
+        helm.sh/chart: snyk-broker-2.2.2
       name: github-com-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -514,7 +514,7 @@ preflight checks off:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.2.1
+        helm.sh/chart: snyk-broker-2.2.2
       name: github-com-broker-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -541,6 +541,6 @@ preflight checks off:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.2.1
+        helm.sh/chart: snyk-broker-2.2.2
       name: snyk-broker-RELEASE-NAME
       namespace: NAMESPACE

--- a/charts/snyk-broker/tests/__snapshot__/cra_deployment_disablesuffixes_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/cra_deployment_disablesuffixes_test.yaml.snap
@@ -55,7 +55,7 @@ default values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.2.1
+        helm.sh/chart: snyk-broker-2.2.2
       name: cra-service
       namespace: NAMESPACE
     spec:

--- a/charts/snyk-broker/tests/__snapshot__/cra_deployment_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/cra_deployment_test.yaml.snap
@@ -55,7 +55,7 @@ default values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.2.1
+        helm.sh/chart: snyk-broker-2.2.2
       name: cra-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:


### PR DESCRIPTION
aligning secret name in code-agent yaml