### PR TITLE
feat: credential pooling for github and gitlab scms

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -3,6 +3,9 @@ useDefault = true
 
 [allowlist]
 description = "global allow list"
+paths = [
+  'charts/snyk-broker/tests/__snapshot__/*',
+]
 
 # ignoring historical secrets from past commits
 # (not present in the current codebase)

--- a/charts/snyk-broker/Chart.yaml
+++ b/charts/snyk-broker/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: snyk-broker
-version: 2.4.0
+version: 2.5.0
 description: A Helm chart for Kubernetes
 type: application

--- a/charts/snyk-broker/templates/broker_deployment.yaml
+++ b/charts/snyk-broker/templates/broker_deployment.yaml
@@ -113,6 +113,13 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.scmType}}-token{{if not .Values.disableSuffixes }}-{{ .Release.Name }}{{ end }}
                   key: "{{ .Values.scmType}}-token-key"
+            {{- if .Values.scmTokenPool }}
+            - name: GITHUB_TOKEN_POOL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.scmType }}-token-pool{{if not .Values.disableSuffixes }}-{{ .Release.Name }}{{ end }}
+                  key: "{{ .Values.scmType}}-token-key-pool"
+                {{- end }}
             - name: PORT
               value: {{ .Values.deployment.container.containerPort | squote }}
             - name: BROKER_CLIENT_URL
@@ -130,6 +137,13 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.scmType}}-token{{if not .Values.disableSuffixes }}-{{ .Release.Name }}{{ end }}
                   key: "{{ .Values.scmType}}-token-key"
+            {{- if .Values.scmTokenPool }}
+            - name: GITHUB_TOKEN_POOL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.scmType }}-token-pool{{if not .Values.disableSuffixes }}-{{ .Release.Name }}{{ end }}
+                  key: "{{ .Values.scmType}}-token-key-pool"
+            {{- end }}
             - name: GITHUB
               value: {{ .Values.github }}
             - name: GITHUB_API
@@ -177,6 +191,13 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.scmType}}-token{{if not .Values.disableSuffixes }}-{{ .Release.Name }}{{ end }}
                   key: "{{ .Values.scmType}}-token-key"
+            {{- if .Values.scmTokenPool }}
+            - name: GITLAB_TOKEN_POOL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.scmType }}-token-pool{{if not .Values.disableSuffixes }}-{{ .Release.Name }}{{ end }}
+                  key: "{{ .Values.scmType}}-token-key-pool"
+                {{- end }}
             - name: GITLAB
               value: {{ .Values.gitlab }}
             - name: PORT

--- a/charts/snyk-broker/templates/secrets.yaml
+++ b/charts/snyk-broker/templates/secrets.yaml
@@ -16,8 +16,18 @@ metadata:
 type: Opaque
 data:
   "{{ .Values.scmType}}-token-key": {{ .Values.scmToken | b64enc | quote }}
----
 {{- end }}
+---
+{{- if .Values.scmTokenPool }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.scmType }}-token-pool{{if not .Values.disableSuffixes }}-{{ .Release.Name }}{{ end }}
+type: Opaque
+data:
+  "{{ .Values.scmType }}-token-key-pool": {{ .Values.scmTokenPool | b64enc | quote }}
+{{- end }}
+---
 {{- if .Values.bitbucketPassword }}
 apiVersion: v1
 kind: Secret

--- a/charts/snyk-broker/tests/__snapshot__/broker_cra_deployment_disablesuffixes_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/broker_cra_deployment_disablesuffixes_test.yaml.snap
@@ -7,7 +7,7 @@ with CRA:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.4.0
+        helm.sh/chart: snyk-broker-2.5.0
       name: container-registry-agent-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -106,7 +106,7 @@ with CRA:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.4.0
+        helm.sh/chart: snyk-broker-2.5.0
       name: container-registry-agent-broker-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -133,6 +133,6 @@ with CRA:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.4.0
+        helm.sh/chart: snyk-broker-2.5.0
       name: snyk-broker-RELEASE-NAME
       namespace: NAMESPACE

--- a/charts/snyk-broker/tests/__snapshot__/broker_cra_deployment_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/broker_cra_deployment_test.yaml.snap
@@ -7,7 +7,7 @@ with CRA:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.4.0
+        helm.sh/chart: snyk-broker-2.5.0
       name: container-registry-agent-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -106,7 +106,7 @@ with CRA:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.4.0
+        helm.sh/chart: snyk-broker-2.5.0
       name: container-registry-agent-broker-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -133,6 +133,6 @@ with CRA:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.4.0
+        helm.sh/chart: snyk-broker-2.5.0
       name: snyk-broker-RELEASE-NAME
       namespace: NAMESPACE

--- a/charts/snyk-broker/tests/__snapshot__/broker_deployment_apprisk_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/broker_deployment_apprisk_test.yaml.snap
@@ -7,7 +7,7 @@ apprisk enabled:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.4.0
+        helm.sh/chart: snyk-broker-2.5.0
       name: github-com-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -105,7 +105,7 @@ apprisk enabled:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.4.0
+        helm.sh/chart: snyk-broker-2.5.0
       name: github-com-broker-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -132,6 +132,6 @@ apprisk enabled:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.4.0
+        helm.sh/chart: snyk-broker-2.5.0
       name: snyk-broker-RELEASE-NAME
       namespace: NAMESPACE

--- a/charts/snyk-broker/tests/__snapshot__/broker_deployment_configmap_disablesuffixes_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/broker_deployment_configmap_disablesuffixes_test.yaml.snap
@@ -7,7 +7,7 @@ cacert:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.4.0
+        helm.sh/chart: snyk-broker-2.5.0
       name: github-com-broker
       namespace: NAMESPACE
     spec:
@@ -113,7 +113,7 @@ cacert:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.4.0
+        helm.sh/chart: snyk-broker-2.5.0
       name: github-com-broker-service
       namespace: NAMESPACE
     spec:
@@ -155,7 +155,7 @@ cacert:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.4.0
+        helm.sh/chart: snyk-broker-2.5.0
       name: RELEASE-NAME-snyk-broker-cacert-configmap
       namespace: NAMESPACE
   4: |
@@ -174,7 +174,7 @@ cacert:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.4.0
+        helm.sh/chart: snyk-broker-2.5.0
       name: snyk-broker
       namespace: NAMESPACE
 cacertfile:
@@ -186,7 +186,7 @@ cacertfile:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.4.0
+        helm.sh/chart: snyk-broker-2.5.0
       name: github-com-broker
       namespace: NAMESPACE
     spec:
@@ -282,7 +282,7 @@ cacertfile:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.4.0
+        helm.sh/chart: snyk-broker-2.5.0
       name: github-com-broker-service
       namespace: NAMESPACE
     spec:
@@ -303,7 +303,7 @@ cacertfile:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.4.0
+        helm.sh/chart: snyk-broker-2.5.0
       name: RELEASE-NAME-snyk-broker-cacert-configmap
       namespace: NAMESPACE
   4: |
@@ -322,6 +322,6 @@ cacertfile:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.4.0
+        helm.sh/chart: snyk-broker-2.5.0
       name: snyk-broker
       namespace: NAMESPACE

--- a/charts/snyk-broker/tests/__snapshot__/broker_deployment_configmap_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/broker_deployment_configmap_test.yaml.snap
@@ -7,7 +7,7 @@ cacert:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.4.0
+        helm.sh/chart: snyk-broker-2.5.0
       name: github-com-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -113,7 +113,7 @@ cacert:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.4.0
+        helm.sh/chart: snyk-broker-2.5.0
       name: github-com-broker-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -155,7 +155,7 @@ cacert:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.4.0
+        helm.sh/chart: snyk-broker-2.5.0
       name: RELEASE-NAME-snyk-broker-cacert-configmap-RELEASE-NAME
       namespace: NAMESPACE
   4: |
@@ -174,7 +174,7 @@ cacert:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.4.0
+        helm.sh/chart: snyk-broker-2.5.0
       name: snyk-broker-RELEASE-NAME
       namespace: NAMESPACE
 cacertfile:
@@ -186,7 +186,7 @@ cacertfile:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.4.0
+        helm.sh/chart: snyk-broker-2.5.0
       name: github-com-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -282,7 +282,7 @@ cacertfile:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.4.0
+        helm.sh/chart: snyk-broker-2.5.0
       name: github-com-broker-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -303,7 +303,7 @@ cacertfile:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.4.0
+        helm.sh/chart: snyk-broker-2.5.0
       name: RELEASE-NAME-snyk-broker-cacert-configmap-RELEASE-NAME
       namespace: NAMESPACE
   4: |
@@ -322,6 +322,6 @@ cacertfile:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.4.0
+        helm.sh/chart: snyk-broker-2.5.0
       name: snyk-broker-RELEASE-NAME
       namespace: NAMESPACE

--- a/charts/snyk-broker/tests/__snapshot__/broker_deployment_customaccept_disablesuffixes_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/broker_deployment_customaccept_disablesuffixes_test.yaml.snap
@@ -9,7 +9,7 @@ customaccept values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.4.0
+        helm.sh/chart: snyk-broker-2.5.0
       name: RELEASE-NAME-snyk-broker-accept-configmap
       namespace: NAMESPACE
   2: |
@@ -20,7 +20,7 @@ customaccept values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.4.0
+        helm.sh/chart: snyk-broker-2.5.0
       name: github-com-broker
       namespace: NAMESPACE
     spec:
@@ -120,7 +120,7 @@ customaccept values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.4.0
+        helm.sh/chart: snyk-broker-2.5.0
       name: github-com-broker-service
       namespace: NAMESPACE
     spec:
@@ -147,6 +147,6 @@ customaccept values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.4.0
+        helm.sh/chart: snyk-broker-2.5.0
       name: snyk-broker
       namespace: NAMESPACE

--- a/charts/snyk-broker/tests/__snapshot__/broker_deployment_customaccept_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/broker_deployment_customaccept_test.yaml.snap
@@ -9,7 +9,7 @@ customaccept values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.4.0
+        helm.sh/chart: snyk-broker-2.5.0
       name: RELEASE-NAME-snyk-broker-accept-configmap-RELEASE-NAME
       namespace: NAMESPACE
   2: |
@@ -20,7 +20,7 @@ customaccept values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.4.0
+        helm.sh/chart: snyk-broker-2.5.0
       name: github-com-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -120,7 +120,7 @@ customaccept values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.4.0
+        helm.sh/chart: snyk-broker-2.5.0
       name: github-com-broker-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -147,6 +147,6 @@ customaccept values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.4.0
+        helm.sh/chart: snyk-broker-2.5.0
       name: snyk-broker-RELEASE-NAME
       namespace: NAMESPACE

--- a/charts/snyk-broker/tests/__snapshot__/broker_deployment_disablesuffixes_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/broker_deployment_disablesuffixes_test.yaml.snap
@@ -7,7 +7,7 @@ HA mode on:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.4.0
+        helm.sh/chart: snyk-broker-2.5.0
       name: github-com-broker
       namespace: NAMESPACE
     spec:
@@ -105,7 +105,7 @@ HA mode on:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.4.0
+        helm.sh/chart: snyk-broker-2.5.0
       name: github-com-broker-service
       namespace: NAMESPACE
     spec:
@@ -132,7 +132,7 @@ HA mode on:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.4.0
+        helm.sh/chart: snyk-broker-2.5.0
       name: snyk-broker
       namespace: NAMESPACE
 HA mode on with 4 replicas:
@@ -144,7 +144,7 @@ HA mode on with 4 replicas:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.4.0
+        helm.sh/chart: snyk-broker-2.5.0
       name: github-com-broker
       namespace: NAMESPACE
     spec:
@@ -242,7 +242,7 @@ HA mode on with 4 replicas:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.4.0
+        helm.sh/chart: snyk-broker-2.5.0
       name: github-com-broker-service
       namespace: NAMESPACE
     spec:
@@ -269,7 +269,7 @@ HA mode on with 4 replicas:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.4.0
+        helm.sh/chart: snyk-broker-2.5.0
       name: snyk-broker
       namespace: NAMESPACE
 default values:
@@ -281,7 +281,7 @@ default values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.4.0
+        helm.sh/chart: snyk-broker-2.5.0
       name: github-com-broker
       namespace: NAMESPACE
     spec:
@@ -377,7 +377,7 @@ default values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.4.0
+        helm.sh/chart: snyk-broker-2.5.0
       name: github-com-broker-service
       namespace: NAMESPACE
     spec:
@@ -404,7 +404,7 @@ default values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.4.0
+        helm.sh/chart: snyk-broker-2.5.0
       name: snyk-broker
       namespace: NAMESPACE
 preflight checks off:
@@ -416,7 +416,7 @@ preflight checks off:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.4.0
+        helm.sh/chart: snyk-broker-2.5.0
       name: github-com-broker
       namespace: NAMESPACE
     spec:
@@ -514,7 +514,7 @@ preflight checks off:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.4.0
+        helm.sh/chart: snyk-broker-2.5.0
       name: github-com-broker-service
       namespace: NAMESPACE
     spec:
@@ -541,6 +541,6 @@ preflight checks off:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.4.0
+        helm.sh/chart: snyk-broker-2.5.0
       name: snyk-broker
       namespace: NAMESPACE

--- a/charts/snyk-broker/tests/__snapshot__/broker_deployment_ingress_disablesuffixes_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/broker_deployment_ingress_disablesuffixes_test.yaml.snap
@@ -7,7 +7,7 @@ ingress:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.4.0
+        helm.sh/chart: snyk-broker-2.5.0
       name: github-com-broker
       namespace: NAMESPACE
     spec:
@@ -103,7 +103,7 @@ ingress:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.4.0
+        helm.sh/chart: snyk-broker-2.5.0
       name: RELEASE-NAME-snyk-broker
       namespace: NAMESPACE
     spec:
@@ -123,7 +123,7 @@ ingress:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.4.0
+        helm.sh/chart: snyk-broker-2.5.0
       name: github-com-broker-service
       namespace: NAMESPACE
     spec:
@@ -150,6 +150,6 @@ ingress:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.4.0
+        helm.sh/chart: snyk-broker-2.5.0
       name: snyk-broker
       namespace: NAMESPACE

--- a/charts/snyk-broker/tests/__snapshot__/broker_deployment_ingress_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/broker_deployment_ingress_test.yaml.snap
@@ -7,7 +7,7 @@ ingress:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.4.0
+        helm.sh/chart: snyk-broker-2.5.0
       name: github-com-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -103,7 +103,7 @@ ingress:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.4.0
+        helm.sh/chart: snyk-broker-2.5.0
       name: RELEASE-NAME-snyk-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -123,7 +123,7 @@ ingress:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.4.0
+        helm.sh/chart: snyk-broker-2.5.0
       name: github-com-broker-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -150,6 +150,6 @@ ingress:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.4.0
+        helm.sh/chart: snyk-broker-2.5.0
       name: snyk-broker-RELEASE-NAME
       namespace: NAMESPACE

--- a/charts/snyk-broker/tests/__snapshot__/broker_deployment_scm_token_pool_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/broker_deployment_scm_token_pool_test.yaml.snap
@@ -7,7 +7,7 @@ github token pool configured:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.4.0
+        helm.sh/chart: snyk-broker-2.5.0
       name: github-com-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -108,7 +108,7 @@ github token pool configured:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.4.0
+        helm.sh/chart: snyk-broker-2.5.0
       name: github-com-broker-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -143,7 +143,7 @@ github token pool configured:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.4.0
+        helm.sh/chart: snyk-broker-2.5.0
       name: snyk-broker-RELEASE-NAME
       namespace: NAMESPACE
 gitlab token pool configured:
@@ -155,7 +155,7 @@ gitlab token pool configured:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.4.0
+        helm.sh/chart: snyk-broker-2.5.0
       name: gitlab-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -258,7 +258,7 @@ gitlab token pool configured:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.4.0
+        helm.sh/chart: snyk-broker-2.5.0
       name: gitlab-broker-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -293,6 +293,6 @@ gitlab token pool configured:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.4.0
+        helm.sh/chart: snyk-broker-2.5.0
       name: snyk-broker-RELEASE-NAME
       namespace: NAMESPACE

--- a/charts/snyk-broker/tests/__snapshot__/broker_deployment_scm_token_pool_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/broker_deployment_scm_token_pool_test.yaml.snap
@@ -1,0 +1,298 @@
+github token pool configured:
+  1: |
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      labels:
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: snyk-broker-RELEASE-NAME
+        helm.sh/chart: snyk-broker-2.4.0
+      name: github-com-broker-RELEASE-NAME
+      namespace: NAMESPACE
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app.kubernetes.io/instance: RELEASE-NAME
+          app.kubernetes.io/name: snyk-broker-RELEASE-NAME
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/name: snyk-broker-RELEASE-NAME
+        spec:
+          containers:
+            - env:
+                - name: BROKER_SERVER_URL
+                  value: https://broker.test.snyk.io
+                - name: BROKER_HEALTHCHECK_PATH
+                  value: /healthcheck
+                - name: BROKER_SYSTEMCHECK_PATH
+                  value: /systemcheck
+                - name: BROKER_TOKEN
+                  valueFrom:
+                    secretKeyRef:
+                      key: github-com-broker-token-key
+                      name: github-com-broker-token-RELEASE-NAME
+                - name: GITHUB_TOKEN
+                  valueFrom:
+                    secretKeyRef:
+                      key: github-com-token-key
+                      name: github-com-token-RELEASE-NAME
+                - name: GITHUB_TOKEN_POOL
+                  valueFrom:
+                    secretKeyRef:
+                      key: github-com-token-key-pool
+                      name: github-com-token-pool-RELEASE-NAME
+                - name: PORT
+                  value: "8000"
+                - name: BROKER_CLIENT_URL
+                  value: http://brokerclient
+                - name: LOG_LEVEL
+                  value: info
+                - name: LOG_ENABLE_BODY
+                  value: "false"
+                - name: ACCEPT_CODE
+                  value: "true"
+                - name: ACCEPT_IAC
+                  value: tf,yaml,yml,json,tpl
+                - name: BROKER_DISPATCHER_BASE_URL
+                  value: https://api.test.snyk.io
+              image: snyk/broker:github-com
+              imagePullPolicy: Always
+              livenessProbe:
+                failureThreshold: 3
+                httpGet:
+                  path: /healthcheck
+                  port: 8000
+                initialDelaySeconds: 3
+                periodSeconds: 10
+                timeoutSeconds: 1
+              name: github-com-broker-RELEASE-NAME
+              ports:
+                - containerPort: 8000
+                  name: http
+              readinessProbe:
+                failureThreshold: 3
+                httpGet:
+                  path: /healthcheck
+                  port: 8000
+                initialDelaySeconds: 3
+                periodSeconds: 10
+                timeoutSeconds: 1
+              resources:
+                limits:
+                  cpu: 1
+                  memory: 256Mi
+                requests:
+                  cpu: 1
+                  memory: 256Mi
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+                readOnlyRootFilesystem: true
+                runAsNonRoot: true
+                runAsUser: 1000
+              volumeMounts: null
+          securityContext: {}
+          serviceAccountName: snyk-broker-RELEASE-NAME
+          volumes: null
+  2: |
+    apiVersion: v1
+    kind: Service
+    metadata:
+      labels:
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: snyk-broker-RELEASE-NAME
+        helm.sh/chart: snyk-broker-2.4.0
+      name: github-com-broker-service-RELEASE-NAME
+      namespace: NAMESPACE
+    spec:
+      ports:
+        - port: 8000
+          targetPort: 8000
+      selector:
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/name: snyk-broker-RELEASE-NAME
+      type: ClusterIP
+  3: |
+    apiVersion: v1
+    data:
+      github-com-broker-token-key: MTIz
+    kind: Secret
+    metadata:
+      name: github-com-broker-token-RELEASE-NAME
+    type: Opaque
+  4: |
+    apiVersion: v1
+    data:
+      github-com-token-key-pool: Z2hfdG9rZW4xLGdoX3Rva2VuMixnaF90b2tlbjM=
+    kind: Secret
+    metadata:
+      name: github-com-token-pool-RELEASE-NAME
+    type: Opaque
+  5: |
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      labels:
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: snyk-broker-RELEASE-NAME
+        helm.sh/chart: snyk-broker-2.4.0
+      name: snyk-broker-RELEASE-NAME
+      namespace: NAMESPACE
+gitlab token pool configured:
+  1: |
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      labels:
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: snyk-broker-RELEASE-NAME
+        helm.sh/chart: snyk-broker-2.4.0
+      name: gitlab-broker-RELEASE-NAME
+      namespace: NAMESPACE
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app.kubernetes.io/instance: RELEASE-NAME
+          app.kubernetes.io/name: snyk-broker-RELEASE-NAME
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/name: snyk-broker-RELEASE-NAME
+        spec:
+          containers:
+            - env:
+                - name: BROKER_SERVER_URL
+                  value: https://broker.test.snyk.io
+                - name: BROKER_HEALTHCHECK_PATH
+                  value: /healthcheck
+                - name: BROKER_SYSTEMCHECK_PATH
+                  value: /systemcheck
+                - name: BROKER_TOKEN
+                  valueFrom:
+                    secretKeyRef:
+                      key: gitlab-broker-token-key
+                      name: gitlab-broker-token-RELEASE-NAME
+                - name: GITLAB_TOKEN
+                  valueFrom:
+                    secretKeyRef:
+                      key: gitlab-token-key
+                      name: gitlab-token-RELEASE-NAME
+                - name: GITLAB_TOKEN_POOL
+                  valueFrom:
+                    secretKeyRef:
+                      key: gitlab-token-key-pool
+                      name: gitlab-token-pool-RELEASE-NAME
+                - name: GITLAB
+                  value: null
+                - name: PORT
+                  value: "8000"
+                - name: BROKER_CLIENT_URL
+                  value: http://brokerclient
+                - name: LOG_LEVEL
+                  value: info
+                - name: LOG_ENABLE_BODY
+                  value: "false"
+                - name: ACCEPT_CODE
+                  value: "true"
+                - name: ACCEPT_IAC
+                  value: tf,yaml,yml,json,tpl
+                - name: BROKER_DISPATCHER_BASE_URL
+                  value: https://api.test.snyk.io
+              image: snyk/broker:gitlab
+              imagePullPolicy: Always
+              livenessProbe:
+                failureThreshold: 3
+                httpGet:
+                  path: /healthcheck
+                  port: 8000
+                initialDelaySeconds: 3
+                periodSeconds: 10
+                timeoutSeconds: 1
+              name: gitlab-broker-RELEASE-NAME
+              ports:
+                - containerPort: 8000
+                  name: http
+              readinessProbe:
+                failureThreshold: 3
+                httpGet:
+                  path: /healthcheck
+                  port: 8000
+                initialDelaySeconds: 3
+                periodSeconds: 10
+                timeoutSeconds: 1
+              resources:
+                limits:
+                  cpu: 1
+                  memory: 256Mi
+                requests:
+                  cpu: 1
+                  memory: 256Mi
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+                readOnlyRootFilesystem: true
+                runAsNonRoot: true
+                runAsUser: 1000
+              volumeMounts: null
+          securityContext: {}
+          serviceAccountName: snyk-broker-RELEASE-NAME
+          volumes: null
+  2: |
+    apiVersion: v1
+    kind: Service
+    metadata:
+      labels:
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: snyk-broker-RELEASE-NAME
+        helm.sh/chart: snyk-broker-2.4.0
+      name: gitlab-broker-service-RELEASE-NAME
+      namespace: NAMESPACE
+    spec:
+      ports:
+        - port: 8000
+          targetPort: 8000
+      selector:
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/name: snyk-broker-RELEASE-NAME
+      type: ClusterIP
+  3: |
+    apiVersion: v1
+    data:
+      gitlab-broker-token-key: MTIz
+    kind: Secret
+    metadata:
+      name: gitlab-broker-token-RELEASE-NAME
+    type: Opaque
+  4: |
+    apiVersion: v1
+    data:
+      gitlab-token-key-pool: Z2xfdG9rZW5fMSxnbF90b2tlbl8y
+    kind: Secret
+    metadata:
+      name: gitlab-token-pool-RELEASE-NAME
+    type: Opaque
+  5: |
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      labels:
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: snyk-broker-RELEASE-NAME
+        helm.sh/chart: snyk-broker-2.4.0
+      name: snyk-broker-RELEASE-NAME
+      namespace: NAMESPACE

--- a/charts/snyk-broker/tests/__snapshot__/broker_deployment_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/broker_deployment_test.yaml.snap
@@ -7,7 +7,7 @@ HA mode on:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.4.0
+        helm.sh/chart: snyk-broker-2.5.0
       name: github-com-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -105,7 +105,7 @@ HA mode on:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.4.0
+        helm.sh/chart: snyk-broker-2.5.0
       name: github-com-broker-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -132,7 +132,7 @@ HA mode on:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.4.0
+        helm.sh/chart: snyk-broker-2.5.0
       name: snyk-broker-RELEASE-NAME
       namespace: NAMESPACE
 HA mode on with 4 replicas:
@@ -144,7 +144,7 @@ HA mode on with 4 replicas:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.4.0
+        helm.sh/chart: snyk-broker-2.5.0
       name: github-com-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -242,7 +242,7 @@ HA mode on with 4 replicas:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.4.0
+        helm.sh/chart: snyk-broker-2.5.0
       name: github-com-broker-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -269,7 +269,7 @@ HA mode on with 4 replicas:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.4.0
+        helm.sh/chart: snyk-broker-2.5.0
       name: snyk-broker-RELEASE-NAME
       namespace: NAMESPACE
 default values:
@@ -281,7 +281,7 @@ default values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.4.0
+        helm.sh/chart: snyk-broker-2.5.0
       name: github-com-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -377,7 +377,7 @@ default values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.4.0
+        helm.sh/chart: snyk-broker-2.5.0
       name: github-com-broker-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -404,7 +404,7 @@ default values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.4.0
+        helm.sh/chart: snyk-broker-2.5.0
       name: snyk-broker-RELEASE-NAME
       namespace: NAMESPACE
 preflight checks off:
@@ -416,7 +416,7 @@ preflight checks off:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.4.0
+        helm.sh/chart: snyk-broker-2.5.0
       name: github-com-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -514,7 +514,7 @@ preflight checks off:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.4.0
+        helm.sh/chart: snyk-broker-2.5.0
       name: github-com-broker-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -541,6 +541,6 @@ preflight checks off:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.4.0
+        helm.sh/chart: snyk-broker-2.5.0
       name: snyk-broker-RELEASE-NAME
       namespace: NAMESPACE

--- a/charts/snyk-broker/tests/__snapshot__/cra_deployment_digitalocean_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/cra_deployment_digitalocean_test.yaml.snap
@@ -7,7 +7,7 @@ default values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.4.0
+        helm.sh/chart: snyk-broker-2.5.0
       name: container-registry-agent-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -155,7 +155,7 @@ default values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.4.0
+        helm.sh/chart: snyk-broker-2.5.0
       name: cra-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:

--- a/charts/snyk-broker/tests/__snapshot__/cra_deployment_disablesuffixes_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/cra_deployment_disablesuffixes_test.yaml.snap
@@ -7,7 +7,7 @@ default values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.4.0
+        helm.sh/chart: snyk-broker-2.5.0
       name: container-registry-agent-broker
       namespace: NAMESPACE
     spec:
@@ -154,7 +154,7 @@ default values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.4.0
+        helm.sh/chart: snyk-broker-2.5.0
       name: cra-service
       namespace: NAMESPACE
     spec:

--- a/charts/snyk-broker/tests/__snapshot__/cra_deployment_harbor_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/cra_deployment_harbor_test.yaml.snap
@@ -7,7 +7,7 @@ default values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.4.0
+        helm.sh/chart: snyk-broker-2.5.0
       name: container-registry-agent-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -157,7 +157,7 @@ default values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.4.0
+        helm.sh/chart: snyk-broker-2.5.0
       name: cra-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:

--- a/charts/snyk-broker/tests/__snapshot__/cra_deployment_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/cra_deployment_test.yaml.snap
@@ -7,7 +7,7 @@ default values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.4.0
+        helm.sh/chart: snyk-broker-2.5.0
       name: container-registry-agent-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -154,7 +154,7 @@ default values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.4.0
+        helm.sh/chart: snyk-broker-2.5.0
       name: cra-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:

--- a/charts/snyk-broker/tests/broker_deployment_scm_token_pool_test.yaml
+++ b/charts/snyk-broker/tests/broker_deployment_scm_token_pool_test.yaml
@@ -1,0 +1,18 @@
+suite: test broker deployment (credential pooling)
+templates:
+  - broker_deployment.yaml
+  - broker_service.yaml
+  - secrets.yaml
+  - serviceaccount.yaml
+
+tests:
+  - it: github token pool configured
+    values:
+      - ./fixtures/default_values_with_github_scmtokenpool.yaml
+    asserts:
+      - matchSnapshot: {}
+  - it: gitlab token pool configured
+    values:
+      - ./fixtures/default_values_with_gitlab_scmtokenpool.yaml
+    asserts:
+      - matchSnapshot: { }

--- a/charts/snyk-broker/tests/fixtures/default_values_with_github_scmtokenpool.yaml
+++ b/charts/snyk-broker/tests/fixtures/default_values_with_github_scmtokenpool.yaml
@@ -1,0 +1,28 @@
+# Default values for snyk-broker.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+##### Snyk Specific Values #####
+
+# Broker Token is a value from Snyk. Get this from the integration settings page or your Snyk Representative
+brokerToken: "123"
+
+# GitHub token pool, comma-separated
+scmType: "github-com"
+scmTokenPool: "gh_token1,gh_token2,gh_token3"
+
+# brokerClientUrl is the address of the broker. This needs to be the address of itself. In the case of Kubernetes, you need to ensure that you are pointing to the cluster ingress you have setup.
+# Ex: http://kubernetes-ingress.domain.com:8000/broker
+brokerClientUrl: "http://brokerclient"
+
+# Do not touch unless directed by a Snyk Representative
+brokerServerUrl: "https://broker.test.snyk.io"
+
+
+preflightChecks:
+  enabled: true
+
+highAvailabilityMode:
+  enabled: false
+brokerDispatcherUrl: "https://api.test.snyk.io"
+

--- a/charts/snyk-broker/tests/fixtures/default_values_with_gitlab_scmtokenpool.yaml
+++ b/charts/snyk-broker/tests/fixtures/default_values_with_gitlab_scmtokenpool.yaml
@@ -1,0 +1,28 @@
+# Default values for snyk-broker.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+##### Snyk Specific Values #####
+
+# Broker Token is a value from Snyk. Get this from the integration settings page or your Snyk Representative
+brokerToken: "123"
+
+# GitLab token pool, comma-separated
+scmTokenPool: "gl_token_1,gl_token_2"
+scmType: "gitlab"
+
+# brokerClientUrl is the address of the broker. This needs to be the address of itself. In the case of Kubernetes, you need to ensure that you are pointing to the cluster ingress you have setup.
+# Ex: http://kubernetes-ingress.domain.com:8000/broker
+brokerClientUrl: "http://brokerclient"
+
+# Do not touch unless directed by a Snyk Representative
+brokerServerUrl: "https://broker.test.snyk.io"
+
+
+preflightChecks:
+  enabled: true
+
+highAvailabilityMode:
+  enabled: false
+brokerDispatcherUrl: "https://api.test.snyk.io"
+

--- a/charts/snyk-broker/values.yaml
+++ b/charts/snyk-broker/values.yaml
@@ -43,9 +43,11 @@ replicaCount: 2
 
 scmType: "github-com"
 
-# scmToken is used for SCMs that require a personal Access Token: Github & Gitlab
+# scmToken is used for SCMs that require a personal Access Token: GitHub & Gitlab
 scmToken: ""
 
+# scmTokenPool is used by credential pooling for SCMs that require a personal Access Token: GitHub & Gitlab
+scmTokenPool: ""
 
 ##### Github Enterprise #####
 


### PR DESCRIPTION
This PR adds a support for [credential pooling](https://docs.snyk.io/enterprise-setup/snyk-broker/install-and-configure-snyk-broker/advanced-configuration-for-snyk-broker-docker-installation/credential-pooling-with-docker-and-helm).

The new value is `scmTokenPool` and can be configured with comma-separated tokens.