### PR TITLE
fix(credential-pooling): allow to force credential pooling

### DIFF
--- a/charts/snyk-broker/Chart.yaml
+++ b/charts/snyk-broker/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: snyk-broker
-version: 2.5.0
+version: 2.5.1
 description: A Helm chart for Kubernetes
 type: application

--- a/charts/snyk-broker/templates/broker_deployment.yaml
+++ b/charts/snyk-broker/templates/broker_deployment.yaml
@@ -113,7 +113,7 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.scmType}}-token{{if not .Values.disableSuffixes }}-{{ .Release.Name }}{{ end }}
                   key: "{{ .Values.scmType}}-token-key"
-            {{- if .Values.scmTokenPool }}
+            {{- if or (.Values.scmTokenPool) (.Values.useExternalSecretScmTokenPool) }}
             - name: GITHUB_TOKEN_POOL
               valueFrom:
                 secretKeyRef:
@@ -137,7 +137,7 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.scmType}}-token{{if not .Values.disableSuffixes }}-{{ .Release.Name }}{{ end }}
                   key: "{{ .Values.scmType}}-token-key"
-            {{- if .Values.scmTokenPool }}
+            {{- if or (.Values.scmTokenPool) (.Values.useExternalSecretScmTokenPool) }}
             - name: GITHUB_TOKEN_POOL
               valueFrom:
                 secretKeyRef:
@@ -191,7 +191,7 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.scmType}}-token{{if not .Values.disableSuffixes }}-{{ .Release.Name }}{{ end }}
                   key: "{{ .Values.scmType}}-token-key"
-            {{- if .Values.scmTokenPool }}
+            {{- if or (.Values.scmTokenPool) (.Values.useExternalSecretScmTokenPool) }}
             - name: GITLAB_TOKEN_POOL
               valueFrom:
                 secretKeyRef:

--- a/charts/snyk-broker/tests/__snapshot__/broker_cra_deployment_disablesuffixes_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/broker_cra_deployment_disablesuffixes_test.yaml.snap
@@ -7,7 +7,7 @@ with CRA:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.5.0
+        helm.sh/chart: snyk-broker-2.5.1
       name: container-registry-agent-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -106,7 +106,7 @@ with CRA:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.5.0
+        helm.sh/chart: snyk-broker-2.5.1
       name: container-registry-agent-broker-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -133,6 +133,6 @@ with CRA:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.5.0
+        helm.sh/chart: snyk-broker-2.5.1
       name: snyk-broker-RELEASE-NAME
       namespace: NAMESPACE

--- a/charts/snyk-broker/tests/__snapshot__/broker_cra_deployment_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/broker_cra_deployment_test.yaml.snap
@@ -7,7 +7,7 @@ with CRA:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.5.0
+        helm.sh/chart: snyk-broker-2.5.1
       name: container-registry-agent-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -106,7 +106,7 @@ with CRA:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.5.0
+        helm.sh/chart: snyk-broker-2.5.1
       name: container-registry-agent-broker-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -133,6 +133,6 @@ with CRA:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.5.0
+        helm.sh/chart: snyk-broker-2.5.1
       name: snyk-broker-RELEASE-NAME
       namespace: NAMESPACE

--- a/charts/snyk-broker/tests/__snapshot__/broker_deployment_apprisk_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/broker_deployment_apprisk_test.yaml.snap
@@ -7,7 +7,7 @@ apprisk enabled:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.5.0
+        helm.sh/chart: snyk-broker-2.5.1
       name: github-com-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -105,7 +105,7 @@ apprisk enabled:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.5.0
+        helm.sh/chart: snyk-broker-2.5.1
       name: github-com-broker-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -132,6 +132,6 @@ apprisk enabled:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.5.0
+        helm.sh/chart: snyk-broker-2.5.1
       name: snyk-broker-RELEASE-NAME
       namespace: NAMESPACE

--- a/charts/snyk-broker/tests/__snapshot__/broker_deployment_configmap_disablesuffixes_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/broker_deployment_configmap_disablesuffixes_test.yaml.snap
@@ -7,7 +7,7 @@ cacert:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.5.0
+        helm.sh/chart: snyk-broker-2.5.1
       name: github-com-broker
       namespace: NAMESPACE
     spec:
@@ -113,7 +113,7 @@ cacert:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.5.0
+        helm.sh/chart: snyk-broker-2.5.1
       name: github-com-broker-service
       namespace: NAMESPACE
     spec:
@@ -155,7 +155,7 @@ cacert:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.5.0
+        helm.sh/chart: snyk-broker-2.5.1
       name: RELEASE-NAME-snyk-broker-cacert-configmap
       namespace: NAMESPACE
   4: |
@@ -174,7 +174,7 @@ cacert:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.5.0
+        helm.sh/chart: snyk-broker-2.5.1
       name: snyk-broker
       namespace: NAMESPACE
 cacertfile:
@@ -186,7 +186,7 @@ cacertfile:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.5.0
+        helm.sh/chart: snyk-broker-2.5.1
       name: github-com-broker
       namespace: NAMESPACE
     spec:
@@ -282,7 +282,7 @@ cacertfile:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.5.0
+        helm.sh/chart: snyk-broker-2.5.1
       name: github-com-broker-service
       namespace: NAMESPACE
     spec:
@@ -303,7 +303,7 @@ cacertfile:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.5.0
+        helm.sh/chart: snyk-broker-2.5.1
       name: RELEASE-NAME-snyk-broker-cacert-configmap
       namespace: NAMESPACE
   4: |
@@ -322,6 +322,6 @@ cacertfile:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.5.0
+        helm.sh/chart: snyk-broker-2.5.1
       name: snyk-broker
       namespace: NAMESPACE

--- a/charts/snyk-broker/tests/__snapshot__/broker_deployment_configmap_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/broker_deployment_configmap_test.yaml.snap
@@ -7,7 +7,7 @@ cacert:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.5.0
+        helm.sh/chart: snyk-broker-2.5.1
       name: github-com-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -113,7 +113,7 @@ cacert:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.5.0
+        helm.sh/chart: snyk-broker-2.5.1
       name: github-com-broker-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -155,7 +155,7 @@ cacert:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.5.0
+        helm.sh/chart: snyk-broker-2.5.1
       name: RELEASE-NAME-snyk-broker-cacert-configmap-RELEASE-NAME
       namespace: NAMESPACE
   4: |
@@ -174,7 +174,7 @@ cacert:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.5.0
+        helm.sh/chart: snyk-broker-2.5.1
       name: snyk-broker-RELEASE-NAME
       namespace: NAMESPACE
 cacertfile:
@@ -186,7 +186,7 @@ cacertfile:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.5.0
+        helm.sh/chart: snyk-broker-2.5.1
       name: github-com-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -282,7 +282,7 @@ cacertfile:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.5.0
+        helm.sh/chart: snyk-broker-2.5.1
       name: github-com-broker-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -303,7 +303,7 @@ cacertfile:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.5.0
+        helm.sh/chart: snyk-broker-2.5.1
       name: RELEASE-NAME-snyk-broker-cacert-configmap-RELEASE-NAME
       namespace: NAMESPACE
   4: |
@@ -322,6 +322,6 @@ cacertfile:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.5.0
+        helm.sh/chart: snyk-broker-2.5.1
       name: snyk-broker-RELEASE-NAME
       namespace: NAMESPACE

--- a/charts/snyk-broker/tests/__snapshot__/broker_deployment_customaccept_disablesuffixes_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/broker_deployment_customaccept_disablesuffixes_test.yaml.snap
@@ -9,7 +9,7 @@ customaccept values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.5.0
+        helm.sh/chart: snyk-broker-2.5.1
       name: RELEASE-NAME-snyk-broker-accept-configmap
       namespace: NAMESPACE
   2: |
@@ -20,7 +20,7 @@ customaccept values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.5.0
+        helm.sh/chart: snyk-broker-2.5.1
       name: github-com-broker
       namespace: NAMESPACE
     spec:
@@ -120,7 +120,7 @@ customaccept values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.5.0
+        helm.sh/chart: snyk-broker-2.5.1
       name: github-com-broker-service
       namespace: NAMESPACE
     spec:
@@ -147,6 +147,6 @@ customaccept values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.5.0
+        helm.sh/chart: snyk-broker-2.5.1
       name: snyk-broker
       namespace: NAMESPACE

--- a/charts/snyk-broker/tests/__snapshot__/broker_deployment_customaccept_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/broker_deployment_customaccept_test.yaml.snap
@@ -9,7 +9,7 @@ customaccept values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.5.0
+        helm.sh/chart: snyk-broker-2.5.1
       name: RELEASE-NAME-snyk-broker-accept-configmap-RELEASE-NAME
       namespace: NAMESPACE
   2: |
@@ -20,7 +20,7 @@ customaccept values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.5.0
+        helm.sh/chart: snyk-broker-2.5.1
       name: github-com-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -120,7 +120,7 @@ customaccept values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.5.0
+        helm.sh/chart: snyk-broker-2.5.1
       name: github-com-broker-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -147,6 +147,6 @@ customaccept values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.5.0
+        helm.sh/chart: snyk-broker-2.5.1
       name: snyk-broker-RELEASE-NAME
       namespace: NAMESPACE

--- a/charts/snyk-broker/tests/__snapshot__/broker_deployment_disablesuffixes_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/broker_deployment_disablesuffixes_test.yaml.snap
@@ -7,7 +7,7 @@ HA mode on:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.5.0
+        helm.sh/chart: snyk-broker-2.5.1
       name: github-com-broker
       namespace: NAMESPACE
     spec:
@@ -105,7 +105,7 @@ HA mode on:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.5.0
+        helm.sh/chart: snyk-broker-2.5.1
       name: github-com-broker-service
       namespace: NAMESPACE
     spec:
@@ -132,7 +132,7 @@ HA mode on:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.5.0
+        helm.sh/chart: snyk-broker-2.5.1
       name: snyk-broker
       namespace: NAMESPACE
 HA mode on with 4 replicas:
@@ -144,7 +144,7 @@ HA mode on with 4 replicas:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.5.0
+        helm.sh/chart: snyk-broker-2.5.1
       name: github-com-broker
       namespace: NAMESPACE
     spec:
@@ -242,7 +242,7 @@ HA mode on with 4 replicas:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.5.0
+        helm.sh/chart: snyk-broker-2.5.1
       name: github-com-broker-service
       namespace: NAMESPACE
     spec:
@@ -269,7 +269,7 @@ HA mode on with 4 replicas:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.5.0
+        helm.sh/chart: snyk-broker-2.5.1
       name: snyk-broker
       namespace: NAMESPACE
 default values:
@@ -281,7 +281,7 @@ default values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.5.0
+        helm.sh/chart: snyk-broker-2.5.1
       name: github-com-broker
       namespace: NAMESPACE
     spec:
@@ -377,7 +377,7 @@ default values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.5.0
+        helm.sh/chart: snyk-broker-2.5.1
       name: github-com-broker-service
       namespace: NAMESPACE
     spec:
@@ -404,7 +404,7 @@ default values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.5.0
+        helm.sh/chart: snyk-broker-2.5.1
       name: snyk-broker
       namespace: NAMESPACE
 preflight checks off:
@@ -416,7 +416,7 @@ preflight checks off:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.5.0
+        helm.sh/chart: snyk-broker-2.5.1
       name: github-com-broker
       namespace: NAMESPACE
     spec:
@@ -514,7 +514,7 @@ preflight checks off:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.5.0
+        helm.sh/chart: snyk-broker-2.5.1
       name: github-com-broker-service
       namespace: NAMESPACE
     spec:
@@ -541,6 +541,6 @@ preflight checks off:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.5.0
+        helm.sh/chart: snyk-broker-2.5.1
       name: snyk-broker
       namespace: NAMESPACE

--- a/charts/snyk-broker/tests/__snapshot__/broker_deployment_ingress_disablesuffixes_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/broker_deployment_ingress_disablesuffixes_test.yaml.snap
@@ -7,7 +7,7 @@ ingress:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.5.0
+        helm.sh/chart: snyk-broker-2.5.1
       name: github-com-broker
       namespace: NAMESPACE
     spec:
@@ -103,7 +103,7 @@ ingress:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.5.0
+        helm.sh/chart: snyk-broker-2.5.1
       name: RELEASE-NAME-snyk-broker
       namespace: NAMESPACE
     spec:
@@ -123,7 +123,7 @@ ingress:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.5.0
+        helm.sh/chart: snyk-broker-2.5.1
       name: github-com-broker-service
       namespace: NAMESPACE
     spec:
@@ -150,6 +150,6 @@ ingress:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.5.0
+        helm.sh/chart: snyk-broker-2.5.1
       name: snyk-broker
       namespace: NAMESPACE

--- a/charts/snyk-broker/tests/__snapshot__/broker_deployment_ingress_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/broker_deployment_ingress_test.yaml.snap
@@ -7,7 +7,7 @@ ingress:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.5.0
+        helm.sh/chart: snyk-broker-2.5.1
       name: github-com-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -103,7 +103,7 @@ ingress:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.5.0
+        helm.sh/chart: snyk-broker-2.5.1
       name: RELEASE-NAME-snyk-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -123,7 +123,7 @@ ingress:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.5.0
+        helm.sh/chart: snyk-broker-2.5.1
       name: github-com-broker-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -150,6 +150,6 @@ ingress:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.5.0
+        helm.sh/chart: snyk-broker-2.5.1
       name: snyk-broker-RELEASE-NAME
       namespace: NAMESPACE

--- a/charts/snyk-broker/tests/__snapshot__/broker_deployment_scm_token_pool_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/broker_deployment_scm_token_pool_test.yaml.snap
@@ -7,7 +7,7 @@ github token pool configured:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.5.0
+        helm.sh/chart: snyk-broker-2.5.1
       name: github-com-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -108,7 +108,7 @@ github token pool configured:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.5.0
+        helm.sh/chart: snyk-broker-2.5.1
       name: github-com-broker-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -143,7 +143,7 @@ github token pool configured:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.5.0
+        helm.sh/chart: snyk-broker-2.5.1
       name: snyk-broker-RELEASE-NAME
       namespace: NAMESPACE
 github token pool configured with enabled useExternalSecretScmTokenPool:
@@ -155,7 +155,7 @@ github token pool configured with enabled useExternalSecretScmTokenPool:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.5.0
+        helm.sh/chart: snyk-broker-2.5.1
       name: github-com-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -256,7 +256,7 @@ github token pool configured with enabled useExternalSecretScmTokenPool:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.5.0
+        helm.sh/chart: snyk-broker-2.5.1
       name: github-com-broker-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -283,7 +283,7 @@ github token pool configured with enabled useExternalSecretScmTokenPool:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.5.0
+        helm.sh/chart: snyk-broker-2.5.1
       name: snyk-broker-RELEASE-NAME
       namespace: NAMESPACE
 gitlab token pool configured:
@@ -295,7 +295,7 @@ gitlab token pool configured:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.5.0
+        helm.sh/chart: snyk-broker-2.5.1
       name: gitlab-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -398,7 +398,7 @@ gitlab token pool configured:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.5.0
+        helm.sh/chart: snyk-broker-2.5.1
       name: gitlab-broker-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -433,6 +433,6 @@ gitlab token pool configured:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.5.0
+        helm.sh/chart: snyk-broker-2.5.1
       name: snyk-broker-RELEASE-NAME
       namespace: NAMESPACE

--- a/charts/snyk-broker/tests/__snapshot__/broker_deployment_scm_token_pool_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/broker_deployment_scm_token_pool_test.yaml.snap
@@ -146,6 +146,146 @@ github token pool configured:
         helm.sh/chart: snyk-broker-2.5.0
       name: snyk-broker-RELEASE-NAME
       namespace: NAMESPACE
+github token pool configured with enabled useExternalSecretScmTokenPool:
+  1: |
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      labels:
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: snyk-broker-RELEASE-NAME
+        helm.sh/chart: snyk-broker-2.5.0
+      name: github-com-broker-RELEASE-NAME
+      namespace: NAMESPACE
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app.kubernetes.io/instance: RELEASE-NAME
+          app.kubernetes.io/name: snyk-broker-RELEASE-NAME
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/name: snyk-broker-RELEASE-NAME
+        spec:
+          containers:
+            - env:
+                - name: BROKER_SERVER_URL
+                  value: https://broker.test.snyk.io
+                - name: BROKER_HEALTHCHECK_PATH
+                  value: /healthcheck
+                - name: BROKER_SYSTEMCHECK_PATH
+                  value: /systemcheck
+                - name: BROKER_TOKEN
+                  valueFrom:
+                    secretKeyRef:
+                      key: github-com-broker-token-key
+                      name: github-com-broker-token-RELEASE-NAME
+                - name: GITHUB_TOKEN
+                  valueFrom:
+                    secretKeyRef:
+                      key: github-com-token-key
+                      name: github-com-token-RELEASE-NAME
+                - name: GITHUB_TOKEN_POOL
+                  valueFrom:
+                    secretKeyRef:
+                      key: github-com-token-key-pool
+                      name: github-com-token-pool-RELEASE-NAME
+                - name: PORT
+                  value: "8000"
+                - name: BROKER_CLIENT_URL
+                  value: http://brokerclient
+                - name: LOG_LEVEL
+                  value: info
+                - name: LOG_ENABLE_BODY
+                  value: "false"
+                - name: ACCEPT_CODE
+                  value: "true"
+                - name: ACCEPT_IAC
+                  value: tf,yaml,yml,json,tpl
+                - name: BROKER_DISPATCHER_BASE_URL
+                  value: https://api.test.snyk.io
+              image: snyk/broker:github-com
+              imagePullPolicy: Always
+              livenessProbe:
+                failureThreshold: 3
+                httpGet:
+                  path: /healthcheck
+                  port: 8000
+                initialDelaySeconds: 3
+                periodSeconds: 10
+                timeoutSeconds: 1
+              name: github-com-broker-RELEASE-NAME
+              ports:
+                - containerPort: 8000
+                  name: http
+              readinessProbe:
+                failureThreshold: 3
+                httpGet:
+                  path: /healthcheck
+                  port: 8000
+                initialDelaySeconds: 3
+                periodSeconds: 10
+                timeoutSeconds: 1
+              resources:
+                limits:
+                  cpu: 1
+                  memory: 256Mi
+                requests:
+                  cpu: 1
+                  memory: 256Mi
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+                readOnlyRootFilesystem: true
+                runAsNonRoot: true
+                runAsUser: 1000
+              volumeMounts: null
+          securityContext: {}
+          serviceAccountName: snyk-broker-RELEASE-NAME
+          volumes: null
+  2: |
+    apiVersion: v1
+    kind: Service
+    metadata:
+      labels:
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: snyk-broker-RELEASE-NAME
+        helm.sh/chart: snyk-broker-2.5.0
+      name: github-com-broker-service-RELEASE-NAME
+      namespace: NAMESPACE
+    spec:
+      ports:
+        - port: 8000
+          targetPort: 8000
+      selector:
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/name: snyk-broker-RELEASE-NAME
+      type: ClusterIP
+  3: |
+    apiVersion: v1
+    data:
+      github-com-broker-token-key: MTIz
+    kind: Secret
+    metadata:
+      name: github-com-broker-token-RELEASE-NAME
+    type: Opaque
+  4: |
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      labels:
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: snyk-broker-RELEASE-NAME
+        helm.sh/chart: snyk-broker-2.5.0
+      name: snyk-broker-RELEASE-NAME
+      namespace: NAMESPACE
 gitlab token pool configured:
   1: |
     apiVersion: apps/v1

--- a/charts/snyk-broker/tests/__snapshot__/broker_deployment_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/broker_deployment_test.yaml.snap
@@ -7,7 +7,7 @@ HA mode on:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.5.0
+        helm.sh/chart: snyk-broker-2.5.1
       name: github-com-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -105,7 +105,7 @@ HA mode on:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.5.0
+        helm.sh/chart: snyk-broker-2.5.1
       name: github-com-broker-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -132,7 +132,7 @@ HA mode on:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.5.0
+        helm.sh/chart: snyk-broker-2.5.1
       name: snyk-broker-RELEASE-NAME
       namespace: NAMESPACE
 HA mode on with 4 replicas:
@@ -144,7 +144,7 @@ HA mode on with 4 replicas:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.5.0
+        helm.sh/chart: snyk-broker-2.5.1
       name: github-com-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -242,7 +242,7 @@ HA mode on with 4 replicas:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.5.0
+        helm.sh/chart: snyk-broker-2.5.1
       name: github-com-broker-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -269,7 +269,7 @@ HA mode on with 4 replicas:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.5.0
+        helm.sh/chart: snyk-broker-2.5.1
       name: snyk-broker-RELEASE-NAME
       namespace: NAMESPACE
 default values:
@@ -281,7 +281,7 @@ default values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.5.0
+        helm.sh/chart: snyk-broker-2.5.1
       name: github-com-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -377,7 +377,7 @@ default values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.5.0
+        helm.sh/chart: snyk-broker-2.5.1
       name: github-com-broker-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -404,7 +404,7 @@ default values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.5.0
+        helm.sh/chart: snyk-broker-2.5.1
       name: snyk-broker-RELEASE-NAME
       namespace: NAMESPACE
 preflight checks off:
@@ -416,7 +416,7 @@ preflight checks off:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.5.0
+        helm.sh/chart: snyk-broker-2.5.1
       name: github-com-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -514,7 +514,7 @@ preflight checks off:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.5.0
+        helm.sh/chart: snyk-broker-2.5.1
       name: github-com-broker-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -541,6 +541,6 @@ preflight checks off:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.5.0
+        helm.sh/chart: snyk-broker-2.5.1
       name: snyk-broker-RELEASE-NAME
       namespace: NAMESPACE

--- a/charts/snyk-broker/tests/__snapshot__/cra_deployment_digitalocean_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/cra_deployment_digitalocean_test.yaml.snap
@@ -7,7 +7,7 @@ default values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.5.0
+        helm.sh/chart: snyk-broker-2.5.1
       name: container-registry-agent-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -155,7 +155,7 @@ default values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.5.0
+        helm.sh/chart: snyk-broker-2.5.1
       name: cra-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:

--- a/charts/snyk-broker/tests/__snapshot__/cra_deployment_disablesuffixes_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/cra_deployment_disablesuffixes_test.yaml.snap
@@ -7,7 +7,7 @@ default values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.5.0
+        helm.sh/chart: snyk-broker-2.5.1
       name: container-registry-agent-broker
       namespace: NAMESPACE
     spec:
@@ -154,7 +154,7 @@ default values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.5.0
+        helm.sh/chart: snyk-broker-2.5.1
       name: cra-service
       namespace: NAMESPACE
     spec:

--- a/charts/snyk-broker/tests/__snapshot__/cra_deployment_harbor_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/cra_deployment_harbor_test.yaml.snap
@@ -7,7 +7,7 @@ default values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.5.0
+        helm.sh/chart: snyk-broker-2.5.1
       name: container-registry-agent-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -157,7 +157,7 @@ default values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.5.0
+        helm.sh/chart: snyk-broker-2.5.1
       name: cra-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:

--- a/charts/snyk-broker/tests/__snapshot__/cra_deployment_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/cra_deployment_test.yaml.snap
@@ -7,7 +7,7 @@ default values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.5.0
+        helm.sh/chart: snyk-broker-2.5.1
       name: container-registry-agent-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -154,7 +154,7 @@ default values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.5.0
+        helm.sh/chart: snyk-broker-2.5.1
       name: cra-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:

--- a/charts/snyk-broker/tests/broker_deployment_scm_token_pool_test.yaml
+++ b/charts/snyk-broker/tests/broker_deployment_scm_token_pool_test.yaml
@@ -15,4 +15,9 @@ tests:
     values:
       - ./fixtures/default_values_with_gitlab_scmtokenpool.yaml
     asserts:
-      - matchSnapshot: { }
+      - matchSnapshot: {}
+  - it: github token pool configured with enabled useExternalSecretScmTokenPool
+    values:
+      - ./fixtures/default_values_with_github_useexternalsecretscmtokenpool_true.yaml
+    asserts:
+      - matchSnapshot: {}

--- a/charts/snyk-broker/tests/fixtures/default_values_with_github_useexternalsecretscmtokenpool_true.yaml
+++ b/charts/snyk-broker/tests/fixtures/default_values_with_github_useexternalsecretscmtokenpool_true.yaml
@@ -1,0 +1,29 @@
+# Default values for snyk-broker.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+##### Snyk Specific Values #####
+
+# Broker Token is a value from Snyk. Get this from the integration settings page or your Snyk Representative
+brokerToken: "123"
+
+# GitHub token pool, comma-separated
+scmType: "github-com"
+scmTokenPool: ""
+useExternalSecretScmTokenPool: true
+
+# brokerClientUrl is the address of the broker. This needs to be the address of itself. In the case of Kubernetes, you need to ensure that you are pointing to the cluster ingress you have setup.
+# Ex: http://kubernetes-ingress.domain.com:8000/broker
+brokerClientUrl: "http://brokerclient"
+
+# Do not touch unless directed by a Snyk Representative
+brokerServerUrl: "https://broker.test.snyk.io"
+
+
+preflightChecks:
+  enabled: true
+
+highAvailabilityMode:
+  enabled: false
+brokerDispatcherUrl: "https://api.test.snyk.io"
+

--- a/charts/snyk-broker/values.yaml
+++ b/charts/snyk-broker/values.yaml
@@ -49,6 +49,9 @@ scmToken: ""
 # scmTokenPool is used by credential pooling for SCMs that require a personal Access Token: GitHub & Gitlab
 scmTokenPool: ""
 
+# useExternalSecretScmTokenPool forces credential pooling for SCMs, e.g. by using Secrets Store CSI Driver (default is false).
+useExternalSecretScmTokenPool: false
+
 ##### Github Enterprise #####
 
 # GHE URL - Ex: your.ghe.domain.com (do not prepend HTTPS) - For GHE Cloud use api.github.com


### PR DESCRIPTION
This PR allows to force usage of credential pooling with additional variable `useExternalSecretScmTokenPool`. Default value is **false**.

It might be useful when configuring envvars via [Secrets Store CSI Driver](https://secrets-store-csi-driver.sigs.k8s.io/topics/set-as-env-var).