### PR TITLE
chore: update codeowners to hybrid

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
-* @snyk/team-broker
+* @snyk/hybrid
 
 charts/snyk-broker/templates/cra_deployment.yaml @snyk/container-integration
 charts/snyk-broker/tests/broker_cra_deployment_test.yaml @snyk/container-integration


### PR DESCRIPTION
This PR updates codeowners to the `hybrid` team.