### PR TITLE
bug: adding https scheme for liveness and readiness probe[HYB-475]

### DIFF
--- a/charts/snyk-broker/templates/broker_deployment.yaml
+++ b/charts/snyk-broker/templates/broker_deployment.yaml
@@ -58,6 +58,11 @@ spec:
             httpGet:
               port: {{ .Values.deployment.container.containerPort }}
               path: {{ .Values.brokerLivenessProbe.path }}
+              {{- if and (.Values.httpsCert) (.Values.httpsKey) }}
+              scheme: HTTPS
+              {{- else }}
+              scheme: HTTP
+              {{- end }}
             {{- toYaml .Values.brokerLivenessProbe.config | nindent 12 }}
           {{- end }}
           {{- if .Values.brokerReadinessProbe.enabled }}
@@ -65,6 +70,11 @@ spec:
             httpGet:
               port: {{ .Values.deployment.container.containerPort }}
               path: {{ .Values.brokerReadinessProbe.path }}
+              {{- if and (.Values.httpsCert) (.Values.httpsKey) }}
+              scheme: HTTPS
+              {{- else }}
+              scheme: HTTP
+              {{- end }}
             {{- toYaml .Values.brokerReadinessProbe.config | nindent 12 }}
           {{- end }}
           {{- if .Values.extraContainerSpecs }}


### PR DESCRIPTION
What:
- Adding HTTPS scheme for Liveness and Readiness prob when TLS certs are defined.

Why:
- liveness probe and readiness probe are not configured to use HTTPS in current broker deployment