### PR TITLE
fix: create volume mount with cacert when caCertFile is defined

### DIFF
--- a/charts/snyk-broker/Chart.yaml
+++ b/charts/snyk-broker/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: snyk-broker
-version: 2.6.2
+version: 2.6.3
 description: A Helm chart for Kubernetes
 type: application

--- a/charts/snyk-broker/templates/broker_deployment.yaml
+++ b/charts/snyk-broker/templates/broker_deployment.yaml
@@ -86,7 +86,7 @@ spec:
                 mountPath: /home/node/private
                 readOnly: true
               {{- end }}
-              {{- if .Values.caCert }}
+              {{- if or (.Values.caCert) (.Values.caCertFile) }}
               - name: {{ include "snyk-broker.fullname" . }}-cacert-volume
                 mountPath: /home/node/cacert
                 readOnly: true
@@ -95,7 +95,7 @@ spec:
               - name: {{ include "snyk-broker.fullname" . }}-tls-secret-volume
                 mountPath: /home/node/tls-cert/
                 readOnly: true
-              {{- end }}                 
+              {{- end }}
 {{- if .Values.extraVolumeMounts }}
 {{ tpl (toYaml .Values.extraVolumeMounts | indent 14) . }}
 {{- end }}
@@ -373,13 +373,20 @@ spec:
               value: {{ .Values.logLevel }}
             - name: LOG_ENABLE_BODY
               value: {{ .Values.logEnableBody | squote }}
-             
-         {{- if .Values.caCert }}
+
+         {{- if and (.Values.caCert) (not .Values.caCertFile) }}
          # HTTPS Inspection 
             - name: CA_CERT
               value: /home/node/cacert/{{ .Values.caCert }}
             - name: NODE_EXTRA_CA_CERTS
               value: /home/node/cacert/{{ .Values.caCert }}
+         {{- end }}
+         {{- if and (.Values.caCertFile) (not .Values.caCert) }}
+          # HTTPS Inspection
+            - name: CA_CERT
+              value: /home/node/cacert/cacert
+            - name: NODE_EXTRA_CA_CERTS
+              value: /home/node/cacert/cacert
          {{- end }}
          
          {{- if .Values.httpsCert }}
@@ -460,7 +467,7 @@ spec:
         configMap:
           name: {{ include "snyk-broker.fullname" . }}-accept-configmap{{if not .Values.disableSuffixes }}-{{ .Release.Name }}{{ end }}
       {{- end }}
-      {{- if .Values.caCert }}
+      {{- if or (.Values.caCert) (.Values.caCertFile) }}
       - name: {{ include "snyk-broker.fullname" . }}-cacert-volume
         configMap:
           name: {{ include "snyk-broker.fullname" . }}-cacert-configmap{{if not .Values.disableSuffixes }}-{{ .Release.Name }}{{ end }}

--- a/charts/snyk-broker/templates/cacert_configmap.yaml
+++ b/charts/snyk-broker/templates/cacert_configmap.yaml
@@ -19,5 +19,5 @@ metadata:
   labels:
     {{- include "snyk-broker.labels" . | nindent 4 }}
 data:
-  cacert: {{ .Values.caCertFile | nindent 4}}
+  cacert: {{ .Values.caCertFile | toYaml | nindent 4}}
 {{- end }}

--- a/charts/snyk-broker/tests/__snapshot__/broker_cra_deployment_disablesuffixes_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/broker_cra_deployment_disablesuffixes_test.yaml.snap
@@ -7,7 +7,7 @@ with CRA:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.2
+        helm.sh/chart: snyk-broker-2.6.3
       name: container-registry-agent-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -108,7 +108,7 @@ with CRA:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.2
+        helm.sh/chart: snyk-broker-2.6.3
       name: container-registry-agent-broker-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -135,6 +135,6 @@ with CRA:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.2
+        helm.sh/chart: snyk-broker-2.6.3
       name: snyk-broker-RELEASE-NAME
       namespace: NAMESPACE

--- a/charts/snyk-broker/tests/__snapshot__/broker_cra_deployment_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/broker_cra_deployment_test.yaml.snap
@@ -7,7 +7,7 @@ with CRA:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.2
+        helm.sh/chart: snyk-broker-2.6.3
       name: container-registry-agent-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -108,7 +108,7 @@ with CRA:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.2
+        helm.sh/chart: snyk-broker-2.6.3
       name: container-registry-agent-broker-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -135,6 +135,6 @@ with CRA:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.2
+        helm.sh/chart: snyk-broker-2.6.3
       name: snyk-broker-RELEASE-NAME
       namespace: NAMESPACE

--- a/charts/snyk-broker/tests/__snapshot__/broker_deployment_apprisk_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/broker_deployment_apprisk_test.yaml.snap
@@ -7,7 +7,7 @@ apprisk enabled:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.2
+        helm.sh/chart: snyk-broker-2.6.3
       name: github-com-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -107,7 +107,7 @@ apprisk enabled:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.2
+        helm.sh/chart: snyk-broker-2.6.3
       name: github-com-broker-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -134,6 +134,6 @@ apprisk enabled:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.2
+        helm.sh/chart: snyk-broker-2.6.3
       name: snyk-broker-RELEASE-NAME
       namespace: NAMESPACE

--- a/charts/snyk-broker/tests/__snapshot__/broker_deployment_configmap_disablesuffixes_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/broker_deployment_configmap_disablesuffixes_test.yaml.snap
@@ -229,6 +229,10 @@ cacertfile:
                   value: info
                 - name: LOG_ENABLE_BODY
                   value: "false"
+                - name: CA_CERT
+                  value: /home/node/cacert/cacert
+                - name: NODE_EXTRA_CA_CERTS
+                  value: /home/node/cacert/cacert
                 - name: ACCEPT_CODE
                   value: "true"
                 - name: ACCEPT_IAC
@@ -274,10 +278,16 @@ cacertfile:
                 readOnlyRootFilesystem: true
                 runAsNonRoot: true
                 runAsUser: 1000
-              volumeMounts: null
+              volumeMounts:
+                - mountPath: /home/node/cacert
+                  name: RELEASE-NAME-snyk-broker-cacert-volume
+                  readOnly: true
           securityContext: {}
           serviceAccountName: snyk-broker
-          volumes: null
+          volumes:
+            - configMap:
+                name: RELEASE-NAME-snyk-broker-cacert-configmap
+              name: RELEASE-NAME-snyk-broker-cacert-volume
   2: |
     apiVersion: v1
     kind: Service

--- a/charts/snyk-broker/tests/__snapshot__/broker_deployment_configmap_disablesuffixes_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/broker_deployment_configmap_disablesuffixes_test.yaml.snap
@@ -7,7 +7,7 @@ cacert:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.6.2
+        helm.sh/chart: snyk-broker-2.6.3
       name: github-com-broker
       namespace: NAMESPACE
     spec:
@@ -115,7 +115,7 @@ cacert:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.6.2
+        helm.sh/chart: snyk-broker-2.6.3
       name: github-com-broker-service
       namespace: NAMESPACE
     spec:
@@ -157,7 +157,7 @@ cacert:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.6.2
+        helm.sh/chart: snyk-broker-2.6.3
       name: RELEASE-NAME-snyk-broker-cacert-configmap
       namespace: NAMESPACE
   4: |
@@ -176,7 +176,7 @@ cacert:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.6.2
+        helm.sh/chart: snyk-broker-2.6.3
       name: snyk-broker
       namespace: NAMESPACE
 cacertfile:
@@ -188,7 +188,7 @@ cacertfile:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.6.2
+        helm.sh/chart: snyk-broker-2.6.3
       name: github-com-broker
       namespace: NAMESPACE
     spec:
@@ -296,7 +296,7 @@ cacertfile:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.6.2
+        helm.sh/chart: snyk-broker-2.6.3
       name: github-com-broker-service
       namespace: NAMESPACE
     spec:
@@ -317,7 +317,7 @@ cacertfile:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.6.2
+        helm.sh/chart: snyk-broker-2.6.3
       name: RELEASE-NAME-snyk-broker-cacert-configmap
       namespace: NAMESPACE
   4: |
@@ -336,6 +336,6 @@ cacertfile:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.6.2
+        helm.sh/chart: snyk-broker-2.6.3
       name: snyk-broker
       namespace: NAMESPACE

--- a/charts/snyk-broker/tests/__snapshot__/broker_deployment_configmap_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/broker_deployment_configmap_test.yaml.snap
@@ -229,6 +229,10 @@ cacertfile:
                   value: info
                 - name: LOG_ENABLE_BODY
                   value: "false"
+                - name: CA_CERT
+                  value: /home/node/cacert/cacert
+                - name: NODE_EXTRA_CA_CERTS
+                  value: /home/node/cacert/cacert
                 - name: ACCEPT_CODE
                   value: "true"
                 - name: ACCEPT_IAC
@@ -274,10 +278,16 @@ cacertfile:
                 readOnlyRootFilesystem: true
                 runAsNonRoot: true
                 runAsUser: 1000
-              volumeMounts: null
+              volumeMounts:
+                - mountPath: /home/node/cacert
+                  name: RELEASE-NAME-snyk-broker-cacert-volume
+                  readOnly: true
           securityContext: {}
           serviceAccountName: snyk-broker-RELEASE-NAME
-          volumes: null
+          volumes:
+            - configMap:
+                name: RELEASE-NAME-snyk-broker-cacert-configmap-RELEASE-NAME
+              name: RELEASE-NAME-snyk-broker-cacert-volume
   2: |
     apiVersion: v1
     kind: Service

--- a/charts/snyk-broker/tests/__snapshot__/broker_deployment_configmap_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/broker_deployment_configmap_test.yaml.snap
@@ -7,7 +7,7 @@ cacert:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.2
+        helm.sh/chart: snyk-broker-2.6.3
       name: github-com-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -115,7 +115,7 @@ cacert:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.2
+        helm.sh/chart: snyk-broker-2.6.3
       name: github-com-broker-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -157,7 +157,7 @@ cacert:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.2
+        helm.sh/chart: snyk-broker-2.6.3
       name: RELEASE-NAME-snyk-broker-cacert-configmap-RELEASE-NAME
       namespace: NAMESPACE
   4: |
@@ -176,7 +176,7 @@ cacert:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.2
+        helm.sh/chart: snyk-broker-2.6.3
       name: snyk-broker-RELEASE-NAME
       namespace: NAMESPACE
 cacertfile:
@@ -188,7 +188,7 @@ cacertfile:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.2
+        helm.sh/chart: snyk-broker-2.6.3
       name: github-com-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -296,7 +296,7 @@ cacertfile:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.2
+        helm.sh/chart: snyk-broker-2.6.3
       name: github-com-broker-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -317,7 +317,7 @@ cacertfile:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.2
+        helm.sh/chart: snyk-broker-2.6.3
       name: RELEASE-NAME-snyk-broker-cacert-configmap-RELEASE-NAME
       namespace: NAMESPACE
   4: |
@@ -336,6 +336,6 @@ cacertfile:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.2
+        helm.sh/chart: snyk-broker-2.6.3
       name: snyk-broker-RELEASE-NAME
       namespace: NAMESPACE

--- a/charts/snyk-broker/tests/__snapshot__/broker_deployment_customaccept_disablesuffixes_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/broker_deployment_customaccept_disablesuffixes_test.yaml.snap
@@ -9,7 +9,7 @@ customaccept values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.6.2
+        helm.sh/chart: snyk-broker-2.6.3
       name: RELEASE-NAME-snyk-broker-accept-configmap
       namespace: NAMESPACE
   2: |
@@ -20,7 +20,7 @@ customaccept values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.6.2
+        helm.sh/chart: snyk-broker-2.6.3
       name: github-com-broker
       namespace: NAMESPACE
     spec:
@@ -122,7 +122,7 @@ customaccept values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.6.2
+        helm.sh/chart: snyk-broker-2.6.3
       name: github-com-broker-service
       namespace: NAMESPACE
     spec:
@@ -149,6 +149,6 @@ customaccept values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.6.2
+        helm.sh/chart: snyk-broker-2.6.3
       name: snyk-broker
       namespace: NAMESPACE

--- a/charts/snyk-broker/tests/__snapshot__/broker_deployment_customaccept_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/broker_deployment_customaccept_test.yaml.snap
@@ -9,7 +9,7 @@ customaccept values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.2
+        helm.sh/chart: snyk-broker-2.6.3
       name: RELEASE-NAME-snyk-broker-accept-configmap-RELEASE-NAME
       namespace: NAMESPACE
   2: |
@@ -20,7 +20,7 @@ customaccept values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.2
+        helm.sh/chart: snyk-broker-2.6.3
       name: github-com-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -122,7 +122,7 @@ customaccept values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.2
+        helm.sh/chart: snyk-broker-2.6.3
       name: github-com-broker-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -149,6 +149,6 @@ customaccept values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.2
+        helm.sh/chart: snyk-broker-2.6.3
       name: snyk-broker-RELEASE-NAME
       namespace: NAMESPACE

--- a/charts/snyk-broker/tests/__snapshot__/broker_deployment_disablesuffixes_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/broker_deployment_disablesuffixes_test.yaml.snap
@@ -7,7 +7,7 @@ HA mode on:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.6.2
+        helm.sh/chart: snyk-broker-2.6.3
       name: github-com-broker
       namespace: NAMESPACE
     spec:
@@ -107,7 +107,7 @@ HA mode on:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.6.2
+        helm.sh/chart: snyk-broker-2.6.3
       name: github-com-broker-service
       namespace: NAMESPACE
     spec:
@@ -134,7 +134,7 @@ HA mode on:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.6.2
+        helm.sh/chart: snyk-broker-2.6.3
       name: snyk-broker
       namespace: NAMESPACE
 HA mode on with 4 replicas:
@@ -146,7 +146,7 @@ HA mode on with 4 replicas:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.6.2
+        helm.sh/chart: snyk-broker-2.6.3
       name: github-com-broker
       namespace: NAMESPACE
     spec:
@@ -246,7 +246,7 @@ HA mode on with 4 replicas:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.6.2
+        helm.sh/chart: snyk-broker-2.6.3
       name: github-com-broker-service
       namespace: NAMESPACE
     spec:
@@ -273,7 +273,7 @@ HA mode on with 4 replicas:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.6.2
+        helm.sh/chart: snyk-broker-2.6.3
       name: snyk-broker
       namespace: NAMESPACE
 default values:
@@ -285,7 +285,7 @@ default values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.6.2
+        helm.sh/chart: snyk-broker-2.6.3
       name: github-com-broker
       namespace: NAMESPACE
     spec:
@@ -383,7 +383,7 @@ default values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.6.2
+        helm.sh/chart: snyk-broker-2.6.3
       name: github-com-broker-service
       namespace: NAMESPACE
     spec:
@@ -410,7 +410,7 @@ default values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.6.2
+        helm.sh/chart: snyk-broker-2.6.3
       name: snyk-broker
       namespace: NAMESPACE
 preflight checks off:
@@ -422,7 +422,7 @@ preflight checks off:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.6.2
+        helm.sh/chart: snyk-broker-2.6.3
       name: github-com-broker
       namespace: NAMESPACE
     spec:
@@ -522,7 +522,7 @@ preflight checks off:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.6.2
+        helm.sh/chart: snyk-broker-2.6.3
       name: github-com-broker-service
       namespace: NAMESPACE
     spec:
@@ -549,6 +549,6 @@ preflight checks off:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.6.2
+        helm.sh/chart: snyk-broker-2.6.3
       name: snyk-broker
       namespace: NAMESPACE

--- a/charts/snyk-broker/tests/__snapshot__/broker_deployment_ingress_disablesuffixes_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/broker_deployment_ingress_disablesuffixes_test.yaml.snap
@@ -7,7 +7,7 @@ ingress:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.6.2
+        helm.sh/chart: snyk-broker-2.6.3
       name: github-com-broker
       namespace: NAMESPACE
     spec:
@@ -105,7 +105,7 @@ ingress:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.6.2
+        helm.sh/chart: snyk-broker-2.6.3
       name: RELEASE-NAME-snyk-broker
       namespace: NAMESPACE
     spec:
@@ -125,7 +125,7 @@ ingress:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.6.2
+        helm.sh/chart: snyk-broker-2.6.3
       name: github-com-broker-service
       namespace: NAMESPACE
     spec:
@@ -152,6 +152,6 @@ ingress:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.6.2
+        helm.sh/chart: snyk-broker-2.6.3
       name: snyk-broker
       namespace: NAMESPACE

--- a/charts/snyk-broker/tests/__snapshot__/broker_deployment_ingress_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/broker_deployment_ingress_test.yaml.snap
@@ -7,7 +7,7 @@ ingress:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.2
+        helm.sh/chart: snyk-broker-2.6.3
       name: github-com-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -105,7 +105,7 @@ ingress:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.2
+        helm.sh/chart: snyk-broker-2.6.3
       name: RELEASE-NAME-snyk-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -125,7 +125,7 @@ ingress:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.2
+        helm.sh/chart: snyk-broker-2.6.3
       name: github-com-broker-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -152,6 +152,6 @@ ingress:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.2
+        helm.sh/chart: snyk-broker-2.6.3
       name: snyk-broker-RELEASE-NAME
       namespace: NAMESPACE

--- a/charts/snyk-broker/tests/__snapshot__/broker_deployment_scm_token_pool_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/broker_deployment_scm_token_pool_test.yaml.snap
@@ -7,7 +7,7 @@ github token pool configured:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.2
+        helm.sh/chart: snyk-broker-2.6.3
       name: github-com-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -110,7 +110,7 @@ github token pool configured:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.2
+        helm.sh/chart: snyk-broker-2.6.3
       name: github-com-broker-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -145,7 +145,7 @@ github token pool configured:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.2
+        helm.sh/chart: snyk-broker-2.6.3
       name: snyk-broker-RELEASE-NAME
       namespace: NAMESPACE
 github token pool configured with enabled useExternalSecretScmTokenPool:
@@ -157,7 +157,7 @@ github token pool configured with enabled useExternalSecretScmTokenPool:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.2
+        helm.sh/chart: snyk-broker-2.6.3
       name: github-com-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -255,7 +255,7 @@ github token pool configured with enabled useExternalSecretScmTokenPool:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.2
+        helm.sh/chart: snyk-broker-2.6.3
       name: github-com-broker-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -282,7 +282,7 @@ github token pool configured with enabled useExternalSecretScmTokenPool:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.2
+        helm.sh/chart: snyk-broker-2.6.3
       name: snyk-broker-RELEASE-NAME
       namespace: NAMESPACE
 gitlab token pool configured:
@@ -294,7 +294,7 @@ gitlab token pool configured:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.2
+        helm.sh/chart: snyk-broker-2.6.3
       name: gitlab-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -399,7 +399,7 @@ gitlab token pool configured:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.2
+        helm.sh/chart: snyk-broker-2.6.3
       name: gitlab-broker-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -434,6 +434,6 @@ gitlab token pool configured:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.2
+        helm.sh/chart: snyk-broker-2.6.3
       name: snyk-broker-RELEASE-NAME
       namespace: NAMESPACE

--- a/charts/snyk-broker/tests/__snapshot__/broker_deployment_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/broker_deployment_test.yaml.snap
@@ -7,7 +7,7 @@ HA mode on:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.2
+        helm.sh/chart: snyk-broker-2.6.3
       name: github-com-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -107,7 +107,7 @@ HA mode on:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.2
+        helm.sh/chart: snyk-broker-2.6.3
       name: github-com-broker-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -134,7 +134,7 @@ HA mode on:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.2
+        helm.sh/chart: snyk-broker-2.6.3
       name: snyk-broker-RELEASE-NAME
       namespace: NAMESPACE
 HA mode on with 4 replicas:
@@ -146,7 +146,7 @@ HA mode on with 4 replicas:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.2
+        helm.sh/chart: snyk-broker-2.6.3
       name: github-com-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -246,7 +246,7 @@ HA mode on with 4 replicas:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.2
+        helm.sh/chart: snyk-broker-2.6.3
       name: github-com-broker-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -273,7 +273,7 @@ HA mode on with 4 replicas:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.2
+        helm.sh/chart: snyk-broker-2.6.3
       name: snyk-broker-RELEASE-NAME
       namespace: NAMESPACE
 HTTPS enabled:
@@ -285,7 +285,7 @@ HTTPS enabled:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.2
+        helm.sh/chart: snyk-broker-2.6.3
       name: github-com-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -393,7 +393,7 @@ HTTPS enabled:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.2
+        helm.sh/chart: snyk-broker-2.6.3
       name: github-com-broker-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -429,7 +429,7 @@ HTTPS enabled:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.2
+        helm.sh/chart: snyk-broker-2.6.3
       name: snyk-broker-RELEASE-NAME
       namespace: NAMESPACE
 default values:
@@ -441,7 +441,7 @@ default values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.2
+        helm.sh/chart: snyk-broker-2.6.3
       name: github-com-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -539,7 +539,7 @@ default values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.2
+        helm.sh/chart: snyk-broker-2.6.3
       name: github-com-broker-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -566,7 +566,7 @@ default values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.2
+        helm.sh/chart: snyk-broker-2.6.3
       name: snyk-broker-RELEASE-NAME
       namespace: NAMESPACE
 preflight checks off:
@@ -578,7 +578,7 @@ preflight checks off:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.2
+        helm.sh/chart: snyk-broker-2.6.3
       name: github-com-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -678,7 +678,7 @@ preflight checks off:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.2
+        helm.sh/chart: snyk-broker-2.6.3
       name: github-com-broker-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -705,6 +705,6 @@ preflight checks off:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.2
+        helm.sh/chart: snyk-broker-2.6.3
       name: snyk-broker-RELEASE-NAME
       namespace: NAMESPACE

--- a/charts/snyk-broker/tests/__snapshot__/cra_deployment_digitalocean_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/cra_deployment_digitalocean_test.yaml.snap
@@ -7,7 +7,7 @@ default values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.2
+        helm.sh/chart: snyk-broker-2.6.3
       name: container-registry-agent-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -157,7 +157,7 @@ default values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.2
+        helm.sh/chart: snyk-broker-2.6.3
       name: cra-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:

--- a/charts/snyk-broker/tests/__snapshot__/cra_deployment_disablesuffixes_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/cra_deployment_disablesuffixes_test.yaml.snap
@@ -7,7 +7,7 @@ default values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.6.2
+        helm.sh/chart: snyk-broker-2.6.3
       name: container-registry-agent-broker
       namespace: NAMESPACE
     spec:
@@ -156,7 +156,7 @@ default values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.6.2
+        helm.sh/chart: snyk-broker-2.6.3
       name: cra-service
       namespace: NAMESPACE
     spec:

--- a/charts/snyk-broker/tests/__snapshot__/cra_deployment_harbor_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/cra_deployment_harbor_test.yaml.snap
@@ -7,7 +7,7 @@ default values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.2
+        helm.sh/chart: snyk-broker-2.6.3
       name: container-registry-agent-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -159,7 +159,7 @@ default values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.2
+        helm.sh/chart: snyk-broker-2.6.3
       name: cra-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:

--- a/charts/snyk-broker/tests/__snapshot__/cra_deployment_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/cra_deployment_test.yaml.snap
@@ -7,7 +7,7 @@ default values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.2
+        helm.sh/chart: snyk-broker-2.6.3
       name: container-registry-agent-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -156,7 +156,7 @@ default values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.2
+        helm.sh/chart: snyk-broker-2.6.3
       name: cra-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:

--- a/charts/snyk-broker/values.yaml
+++ b/charts/snyk-broker/values.yaml
@@ -206,6 +206,8 @@ httpsKey: ""
 # Not supported by Snyk Container Registry Agent or Snyk Code Agent (use tlsRejectUnauthorized instead). Location of mounted custom certificate. To allow visibility for SSL Inspection. 
 caCert: ""
 
+caCertFile: ""
+
 # Set to "0" to disable trust validation when using self signed certificates. 
 tlsRejectUnauthorized: "" 
 


### PR DESCRIPTION
This PR fixes an issue when cacert configmap was not created with defined `caCertFile` value.


#### Developer notes:
Failing unit tests (and snapshots) after fix show that exactly this envvar and volume was not mounted to the deployment.
```
	- asserts[0] `matchSnapshot` fail
			Template:	snyk-broker/templates/broker_deployment.yaml
			DocumentIndex:	0
			Path:	
			Expected to match snapshot 1:
				--- Expected
				+++ Actual
				@@ -48,2 +48,6 @@
				               value: "false"
				+            - name: CA_CERT
				+              value: /home/node/cacert/cacert
				+            - name: NODE_EXTRA_CA_CERTS
				+              value: /home/node/cacert/cacert
				             - name: ACCEPT_CODE
				@@ -93,6 +97,12 @@
				             runAsUser: 1000
				-          volumeMounts: null
				+          volumeMounts:
				+            - mountPath: /home/node/cacert
				+              name: RELEASE-NAME-snyk-broker-cacert-volume
				+              readOnly: true
				       securityContext: {}
				       serviceAccountName: snyk-broker
				-      volumes: null
				+      volumes:
				+        - configMap:
				+            name: RELEASE-NAME-snyk-broker-cacert-configmap
				+          name: RELEASE-NAME-snyk-broker-cacert-volume
``` 