### PR TITLE
fix: use secret for artifactoryUrl

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false
+

--- a/charts/snyk-broker/Chart.yaml
+++ b/charts/snyk-broker/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: snyk-broker
-version: 2.6.3
+version: 2.6.4
 description: A Helm chart for Kubernetes
 type: application

--- a/charts/snyk-broker/templates/broker_deployment.yaml
+++ b/charts/snyk-broker/templates/broker_deployment.yaml
@@ -245,9 +245,21 @@ spec:
                   name: {{ .Values.scmType}}-broker-token{{if not .Values.disableSuffixes }}-{{ .Release.Name }}{{ end }}
                   key: "{{ .Values.scmType}}-broker-token-key"
             - name: ARTIFACTORY_URL
-              value: {{ .Values.artifactoryUrl }}
+              valueFrom:
+                secretKeyRef:
+                  name: artifactory-url{{if not .Values.disableSuffixes }}-{{ .Release.Name }}{{ end }}
+                  key: "artifactory-url"
             - name: PORT
               value: {{ .Values.deployment.container.containerPort | squote }}
+            - name: BROKER_CLIENT_URL
+              value: {{ .Values.brokerClientUrl }}
+            {{- if .Values.brokerClientValidationUrl }}
+            - name: BROKER_CLIENT_VALIDATION_URL
+              valueFrom:
+                secretKeyRef:
+                  name: artifactory-broker-client-validation-url{{if not .Values.disableSuffixes }}-{{ .Release.Name }}{{ end }}
+                  key: "artifactory-broker-client-validation-url"
+            {{- end }}
           {{- end }}
           {{- if or (eq .Values.scmType "nexus") (eq .Values.scmType "nexus2") }}
           # Nexus (3 or 2)
@@ -266,10 +278,8 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.scmType }}-nexus-url{{if not .Values.disableSuffixes }}-{{ .Release.Name }}{{ end }}
                   key: "{{ .Values.scmType}}-nexus-url"
-              
             - name: BROKER_CLIENT_VALIDATION_URL
               value: {{ .Values.brokerClientValidationUrl }}
-
             - name: PORT
               value: {{ .Values.deployment.container.containerPort | squote }}
           {{- end }}
@@ -367,7 +377,7 @@ spec:
           # Snyk Code Local Engine
             - name: GIT_CLIENT_URL
               value: {{ tpl .Values.gitClientUrl . }}
-         {{- end }}        
+         {{- end }}
          # Logging
             - name: LOG_LEVEL
               value: {{ .Values.logLevel }}
@@ -375,7 +385,7 @@ spec:
               value: {{ .Values.logEnableBody | squote }}
 
          {{- if and (.Values.caCert) (not .Values.caCertFile) }}
-         # HTTPS Inspection 
+         # HTTPS Inspection
             - name: CA_CERT
               value: /home/node/cacert/{{ .Values.caCert }}
             - name: NODE_EXTRA_CA_CERTS
@@ -388,7 +398,7 @@ spec:
             - name: NODE_EXTRA_CA_CERTS
               value: /home/node/cacert/cacert
          {{- end }}
-         
+
          {{- if .Values.httpsCert }}
          # HTTPS Config
             - name: HTTPS_CERT
@@ -398,7 +408,7 @@ spec:
             - name: HTTPS_KEY
               value: /home/node/tls-cert/tls.key
          {{- end }}
-         
+
          {{- if .Values.tlsRejectUnauthorized  }}
          # Troubleshooting - Set to 0 for SSL inspection testing
             - name: NODE_TLS_REJECT_UNAUTHORIZED
@@ -456,10 +466,10 @@ spec:
         {{- range .Values.env }}
          # custom env var in override.yaml
             - name: {{ .name }}
-              value: {{ .value | squote }} 
+              value: {{ .value | squote }}
         {{- end}}
             - name: BROKER_DISPATCHER_BASE_URL
-              value: {{ .Values.brokerDispatcherUrl }} 
+              value: {{ .Values.brokerDispatcherUrl }}
       # Mount Accept.json and Certs
       volumes:
       {{- if (include "snyk-broker.acceptJson" .)}}

--- a/charts/snyk-broker/templates/secrets.yaml
+++ b/charts/snyk-broker/templates/secrets.yaml
@@ -98,6 +98,26 @@ data:
   "snyk-token-key": {{ .Values.snykToken | b64enc | quote }}
 ---
 {{- end }}
+{{- if .Values.artifactoryUrl }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: artifactory-url{{if not .Values.disableSuffixes }}-{{ .Release.Name }}{{ end }}
+type: Opaque
+stringData:
+  artifactory-url: {{ .Values.artifactoryUrl | quote }}
+---
+{{- end }}
+{{- if and (.Values.artifactoryUrl) (.Values.brokerClientValidationUrl) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: artifactory-broker-client-validation-url{{if not .Values.disableSuffixes }}-{{ .Release.Name }}{{ end }}
+type: Opaque
+stringData:
+  artifactory-broker-client-validation-url: {{ .Values.brokerClientValidationUrl | quote }}
+---
+{{- end }}
 {{- if .Values.baseNexusUrl }}
 apiVersion: v1
 kind: Secret
@@ -116,7 +136,7 @@ metadata:
 type: Opaque
 data:
   "nexus-nexus-url": {{ .Values.nexusUrl | b64enc | quote }}
----  
+---
 {{- end}}
 {{- if and (.Values.httpsCert) (.Values.httpsKey) }}
 apiVersion: v1
@@ -127,5 +147,5 @@ type: kubernetes.io/tls
 data:
   tls.crt: {{ (.Files.Get .Values.httpsCert) | b64enc | quote }}
   tls.key: {{ (.Files.Get .Values.httpsKey) | b64enc | quote }}
----  
+---
 {{- end }}

--- a/charts/snyk-broker/tests/__snapshot__/broker_cra_deployment_disablesuffixes_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/broker_cra_deployment_disablesuffixes_test.yaml.snap
@@ -7,7 +7,7 @@ with CRA:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.3
+        helm.sh/chart: snyk-broker-2.6.4
       name: container-registry-agent-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -108,7 +108,7 @@ with CRA:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.3
+        helm.sh/chart: snyk-broker-2.6.4
       name: container-registry-agent-broker-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -135,6 +135,6 @@ with CRA:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.3
+        helm.sh/chart: snyk-broker-2.6.4
       name: snyk-broker-RELEASE-NAME
       namespace: NAMESPACE

--- a/charts/snyk-broker/tests/__snapshot__/broker_cra_deployment_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/broker_cra_deployment_test.yaml.snap
@@ -7,7 +7,7 @@ with CRA:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.3
+        helm.sh/chart: snyk-broker-2.6.4
       name: container-registry-agent-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -108,7 +108,7 @@ with CRA:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.3
+        helm.sh/chart: snyk-broker-2.6.4
       name: container-registry-agent-broker-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -135,6 +135,6 @@ with CRA:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.3
+        helm.sh/chart: snyk-broker-2.6.4
       name: snyk-broker-RELEASE-NAME
       namespace: NAMESPACE

--- a/charts/snyk-broker/tests/__snapshot__/broker_deployment_apprisk_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/broker_deployment_apprisk_test.yaml.snap
@@ -7,7 +7,7 @@ apprisk enabled:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.3
+        helm.sh/chart: snyk-broker-2.6.4
       name: github-com-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -107,7 +107,7 @@ apprisk enabled:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.3
+        helm.sh/chart: snyk-broker-2.6.4
       name: github-com-broker-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -134,6 +134,6 @@ apprisk enabled:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.3
+        helm.sh/chart: snyk-broker-2.6.4
       name: snyk-broker-RELEASE-NAME
       namespace: NAMESPACE

--- a/charts/snyk-broker/tests/__snapshot__/broker_deployment_artifactory_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/broker_deployment_artifactory_test.yaml.snap
@@ -7,7 +7,7 @@ should render artifactoryUrl and brokerClientValidationUrl as secrets:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.3
+        helm.sh/chart: snyk-broker-2.6.4
       name: artifactory-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -106,7 +106,7 @@ should render artifactoryUrl and brokerClientValidationUrl as secrets:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.3
+        helm.sh/chart: snyk-broker-2.6.4
       name: artifactory-broker-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -149,6 +149,6 @@ should render artifactoryUrl and brokerClientValidationUrl as secrets:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.3
+        helm.sh/chart: snyk-broker-2.6.4
       name: snyk-broker-RELEASE-NAME
       namespace: NAMESPACE

--- a/charts/snyk-broker/tests/__snapshot__/broker_deployment_artifactory_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/broker_deployment_artifactory_test.yaml.snap
@@ -1,0 +1,154 @@
+should render artifactoryUrl and brokerClientValidationUrl as secrets:
+  1: |
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      labels:
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: snyk-broker-RELEASE-NAME
+        helm.sh/chart: snyk-broker-2.6.3
+      name: artifactory-broker-RELEASE-NAME
+      namespace: NAMESPACE
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app.kubernetes.io/instance: RELEASE-NAME
+          app.kubernetes.io/name: snyk-broker-RELEASE-NAME
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/name: snyk-broker-RELEASE-NAME
+        spec:
+          containers:
+            - env:
+                - name: BROKER_SERVER_URL
+                  value: https://broker.test.snyk.io
+                - name: BROKER_HEALTHCHECK_PATH
+                  value: /healthcheck
+                - name: BROKER_SYSTEMCHECK_PATH
+                  value: /systemcheck
+                - name: BROKER_TOKEN
+                  valueFrom:
+                    secretKeyRef:
+                      key: artifactory-broker-token-key
+                      name: artifactory-broker-token-RELEASE-NAME
+                - name: ARTIFACTORY_URL
+                  valueFrom:
+                    secretKeyRef:
+                      key: artifactory-url
+                      name: artifactory-url-RELEASE-NAME
+                - name: PORT
+                  value: "8000"
+                - name: BROKER_CLIENT_URL
+                  value: http://brokerclient
+                - name: BROKER_CLIENT_VALIDATION_URL
+                  valueFrom:
+                    secretKeyRef:
+                      key: artifactory-broker-client-validation-url
+                      name: artifactory-broker-client-validation-url-RELEASE-NAME
+                - name: LOG_LEVEL
+                  value: info
+                - name: LOG_ENABLE_BODY
+                  value: "false"
+                - name: BROKER_DISPATCHER_BASE_URL
+                  value: https://api.test.snyk.io
+              image: snyk/broker:artifactory
+              imagePullPolicy: Always
+              livenessProbe:
+                failureThreshold: 3
+                httpGet:
+                  path: /healthcheck
+                  port: 8000
+                  scheme: HTTP
+                initialDelaySeconds: 3
+                periodSeconds: 10
+                timeoutSeconds: 1
+              name: artifactory-broker-RELEASE-NAME
+              ports:
+                - containerPort: 8000
+                  name: http
+              readinessProbe:
+                failureThreshold: 3
+                httpGet:
+                  path: /healthcheck
+                  port: 8000
+                  scheme: HTTP
+                initialDelaySeconds: 3
+                periodSeconds: 10
+                timeoutSeconds: 1
+              resources:
+                limits:
+                  cpu: 1
+                  memory: 256Mi
+                requests:
+                  cpu: 1
+                  memory: 256Mi
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+                readOnlyRootFilesystem: true
+                runAsNonRoot: true
+                runAsUser: 1000
+              volumeMounts: null
+          securityContext: {}
+          serviceAccountName: snyk-broker-RELEASE-NAME
+          volumes: null
+  2: |
+    apiVersion: v1
+    kind: Service
+    metadata:
+      labels:
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: snyk-broker-RELEASE-NAME
+        helm.sh/chart: snyk-broker-2.6.3
+      name: artifactory-broker-service-RELEASE-NAME
+      namespace: NAMESPACE
+    spec:
+      ports:
+        - port: 8000
+          targetPort: 8000
+      selector:
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/name: snyk-broker-RELEASE-NAME
+      type: ClusterIP
+  3: |
+    apiVersion: v1
+    data:
+      artifactory-broker-token-key: MTIz
+    kind: Secret
+    metadata:
+      name: artifactory-broker-token-RELEASE-NAME
+    type: Opaque
+  4: |
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: artifactory-url-RELEASE-NAME
+    stringData:
+      artifactory-url: username:password@your-domain.com/artifactory
+    type: Opaque
+  5: |
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: artifactory-broker-client-validation-url-RELEASE-NAME
+    stringData:
+      artifactory-broker-client-validation-url: https://username:password@your-domain.com/artifactory/api/system/ping
+    type: Opaque
+  6: |
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      labels:
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: snyk-broker-RELEASE-NAME
+        helm.sh/chart: snyk-broker-2.6.3
+      name: snyk-broker-RELEASE-NAME
+      namespace: NAMESPACE

--- a/charts/snyk-broker/tests/__snapshot__/broker_deployment_configmap_disablesuffixes_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/broker_deployment_configmap_disablesuffixes_test.yaml.snap
@@ -7,7 +7,7 @@ cacert:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.6.3
+        helm.sh/chart: snyk-broker-2.6.4
       name: github-com-broker
       namespace: NAMESPACE
     spec:
@@ -115,7 +115,7 @@ cacert:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.6.3
+        helm.sh/chart: snyk-broker-2.6.4
       name: github-com-broker-service
       namespace: NAMESPACE
     spec:
@@ -157,7 +157,7 @@ cacert:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.6.3
+        helm.sh/chart: snyk-broker-2.6.4
       name: RELEASE-NAME-snyk-broker-cacert-configmap
       namespace: NAMESPACE
   4: |
@@ -176,7 +176,7 @@ cacert:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.6.3
+        helm.sh/chart: snyk-broker-2.6.4
       name: snyk-broker
       namespace: NAMESPACE
 cacertfile:
@@ -188,7 +188,7 @@ cacertfile:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.6.3
+        helm.sh/chart: snyk-broker-2.6.4
       name: github-com-broker
       namespace: NAMESPACE
     spec:
@@ -296,7 +296,7 @@ cacertfile:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.6.3
+        helm.sh/chart: snyk-broker-2.6.4
       name: github-com-broker-service
       namespace: NAMESPACE
     spec:
@@ -317,7 +317,7 @@ cacertfile:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.6.3
+        helm.sh/chart: snyk-broker-2.6.4
       name: RELEASE-NAME-snyk-broker-cacert-configmap
       namespace: NAMESPACE
   4: |
@@ -336,6 +336,6 @@ cacertfile:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.6.3
+        helm.sh/chart: snyk-broker-2.6.4
       name: snyk-broker
       namespace: NAMESPACE

--- a/charts/snyk-broker/tests/__snapshot__/broker_deployment_configmap_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/broker_deployment_configmap_test.yaml.snap
@@ -7,7 +7,7 @@ cacert:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.3
+        helm.sh/chart: snyk-broker-2.6.4
       name: github-com-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -115,7 +115,7 @@ cacert:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.3
+        helm.sh/chart: snyk-broker-2.6.4
       name: github-com-broker-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -157,7 +157,7 @@ cacert:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.3
+        helm.sh/chart: snyk-broker-2.6.4
       name: RELEASE-NAME-snyk-broker-cacert-configmap-RELEASE-NAME
       namespace: NAMESPACE
   4: |
@@ -176,7 +176,7 @@ cacert:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.3
+        helm.sh/chart: snyk-broker-2.6.4
       name: snyk-broker-RELEASE-NAME
       namespace: NAMESPACE
 cacertfile:
@@ -188,7 +188,7 @@ cacertfile:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.3
+        helm.sh/chart: snyk-broker-2.6.4
       name: github-com-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -296,7 +296,7 @@ cacertfile:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.3
+        helm.sh/chart: snyk-broker-2.6.4
       name: github-com-broker-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -317,7 +317,7 @@ cacertfile:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.3
+        helm.sh/chart: snyk-broker-2.6.4
       name: RELEASE-NAME-snyk-broker-cacert-configmap-RELEASE-NAME
       namespace: NAMESPACE
   4: |
@@ -336,6 +336,6 @@ cacertfile:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.3
+        helm.sh/chart: snyk-broker-2.6.4
       name: snyk-broker-RELEASE-NAME
       namespace: NAMESPACE

--- a/charts/snyk-broker/tests/__snapshot__/broker_deployment_customaccept_disablesuffixes_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/broker_deployment_customaccept_disablesuffixes_test.yaml.snap
@@ -9,7 +9,7 @@ customaccept values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.6.3
+        helm.sh/chart: snyk-broker-2.6.4
       name: RELEASE-NAME-snyk-broker-accept-configmap
       namespace: NAMESPACE
   2: |
@@ -20,7 +20,7 @@ customaccept values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.6.3
+        helm.sh/chart: snyk-broker-2.6.4
       name: github-com-broker
       namespace: NAMESPACE
     spec:
@@ -122,7 +122,7 @@ customaccept values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.6.3
+        helm.sh/chart: snyk-broker-2.6.4
       name: github-com-broker-service
       namespace: NAMESPACE
     spec:
@@ -149,6 +149,6 @@ customaccept values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.6.3
+        helm.sh/chart: snyk-broker-2.6.4
       name: snyk-broker
       namespace: NAMESPACE

--- a/charts/snyk-broker/tests/__snapshot__/broker_deployment_customaccept_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/broker_deployment_customaccept_test.yaml.snap
@@ -9,7 +9,7 @@ customaccept values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.3
+        helm.sh/chart: snyk-broker-2.6.4
       name: RELEASE-NAME-snyk-broker-accept-configmap-RELEASE-NAME
       namespace: NAMESPACE
   2: |
@@ -20,7 +20,7 @@ customaccept values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.3
+        helm.sh/chart: snyk-broker-2.6.4
       name: github-com-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -122,7 +122,7 @@ customaccept values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.3
+        helm.sh/chart: snyk-broker-2.6.4
       name: github-com-broker-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -149,6 +149,6 @@ customaccept values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.3
+        helm.sh/chart: snyk-broker-2.6.4
       name: snyk-broker-RELEASE-NAME
       namespace: NAMESPACE

--- a/charts/snyk-broker/tests/__snapshot__/broker_deployment_disablesuffixes_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/broker_deployment_disablesuffixes_test.yaml.snap
@@ -7,7 +7,7 @@ HA mode on:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.6.3
+        helm.sh/chart: snyk-broker-2.6.4
       name: github-com-broker
       namespace: NAMESPACE
     spec:
@@ -107,7 +107,7 @@ HA mode on:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.6.3
+        helm.sh/chart: snyk-broker-2.6.4
       name: github-com-broker-service
       namespace: NAMESPACE
     spec:
@@ -134,7 +134,7 @@ HA mode on:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.6.3
+        helm.sh/chart: snyk-broker-2.6.4
       name: snyk-broker
       namespace: NAMESPACE
 HA mode on with 4 replicas:
@@ -146,7 +146,7 @@ HA mode on with 4 replicas:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.6.3
+        helm.sh/chart: snyk-broker-2.6.4
       name: github-com-broker
       namespace: NAMESPACE
     spec:
@@ -246,7 +246,7 @@ HA mode on with 4 replicas:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.6.3
+        helm.sh/chart: snyk-broker-2.6.4
       name: github-com-broker-service
       namespace: NAMESPACE
     spec:
@@ -273,7 +273,7 @@ HA mode on with 4 replicas:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.6.3
+        helm.sh/chart: snyk-broker-2.6.4
       name: snyk-broker
       namespace: NAMESPACE
 default values:
@@ -285,7 +285,7 @@ default values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.6.3
+        helm.sh/chart: snyk-broker-2.6.4
       name: github-com-broker
       namespace: NAMESPACE
     spec:
@@ -383,7 +383,7 @@ default values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.6.3
+        helm.sh/chart: snyk-broker-2.6.4
       name: github-com-broker-service
       namespace: NAMESPACE
     spec:
@@ -410,7 +410,7 @@ default values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.6.3
+        helm.sh/chart: snyk-broker-2.6.4
       name: snyk-broker
       namespace: NAMESPACE
 preflight checks off:
@@ -422,7 +422,7 @@ preflight checks off:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.6.3
+        helm.sh/chart: snyk-broker-2.6.4
       name: github-com-broker
       namespace: NAMESPACE
     spec:
@@ -522,7 +522,7 @@ preflight checks off:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.6.3
+        helm.sh/chart: snyk-broker-2.6.4
       name: github-com-broker-service
       namespace: NAMESPACE
     spec:
@@ -549,6 +549,6 @@ preflight checks off:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.6.3
+        helm.sh/chart: snyk-broker-2.6.4
       name: snyk-broker
       namespace: NAMESPACE

--- a/charts/snyk-broker/tests/__snapshot__/broker_deployment_ingress_disablesuffixes_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/broker_deployment_ingress_disablesuffixes_test.yaml.snap
@@ -7,7 +7,7 @@ ingress:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.6.3
+        helm.sh/chart: snyk-broker-2.6.4
       name: github-com-broker
       namespace: NAMESPACE
     spec:
@@ -105,7 +105,7 @@ ingress:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.6.3
+        helm.sh/chart: snyk-broker-2.6.4
       name: RELEASE-NAME-snyk-broker
       namespace: NAMESPACE
     spec:
@@ -125,7 +125,7 @@ ingress:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.6.3
+        helm.sh/chart: snyk-broker-2.6.4
       name: github-com-broker-service
       namespace: NAMESPACE
     spec:
@@ -152,6 +152,6 @@ ingress:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.6.3
+        helm.sh/chart: snyk-broker-2.6.4
       name: snyk-broker
       namespace: NAMESPACE

--- a/charts/snyk-broker/tests/__snapshot__/broker_deployment_ingress_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/broker_deployment_ingress_test.yaml.snap
@@ -7,7 +7,7 @@ ingress:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.3
+        helm.sh/chart: snyk-broker-2.6.4
       name: github-com-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -105,7 +105,7 @@ ingress:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.3
+        helm.sh/chart: snyk-broker-2.6.4
       name: RELEASE-NAME-snyk-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -125,7 +125,7 @@ ingress:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.3
+        helm.sh/chart: snyk-broker-2.6.4
       name: github-com-broker-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -152,6 +152,6 @@ ingress:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.3
+        helm.sh/chart: snyk-broker-2.6.4
       name: snyk-broker-RELEASE-NAME
       namespace: NAMESPACE

--- a/charts/snyk-broker/tests/__snapshot__/broker_deployment_scm_token_pool_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/broker_deployment_scm_token_pool_test.yaml.snap
@@ -7,7 +7,7 @@ github token pool configured:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.3
+        helm.sh/chart: snyk-broker-2.6.4
       name: github-com-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -110,7 +110,7 @@ github token pool configured:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.3
+        helm.sh/chart: snyk-broker-2.6.4
       name: github-com-broker-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -145,7 +145,7 @@ github token pool configured:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.3
+        helm.sh/chart: snyk-broker-2.6.4
       name: snyk-broker-RELEASE-NAME
       namespace: NAMESPACE
 github token pool configured with enabled useExternalSecretScmTokenPool:
@@ -157,7 +157,7 @@ github token pool configured with enabled useExternalSecretScmTokenPool:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.3
+        helm.sh/chart: snyk-broker-2.6.4
       name: github-com-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -255,7 +255,7 @@ github token pool configured with enabled useExternalSecretScmTokenPool:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.3
+        helm.sh/chart: snyk-broker-2.6.4
       name: github-com-broker-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -282,7 +282,7 @@ github token pool configured with enabled useExternalSecretScmTokenPool:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.3
+        helm.sh/chart: snyk-broker-2.6.4
       name: snyk-broker-RELEASE-NAME
       namespace: NAMESPACE
 gitlab token pool configured:
@@ -294,7 +294,7 @@ gitlab token pool configured:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.3
+        helm.sh/chart: snyk-broker-2.6.4
       name: gitlab-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -399,7 +399,7 @@ gitlab token pool configured:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.3
+        helm.sh/chart: snyk-broker-2.6.4
       name: gitlab-broker-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -434,6 +434,6 @@ gitlab token pool configured:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.3
+        helm.sh/chart: snyk-broker-2.6.4
       name: snyk-broker-RELEASE-NAME
       namespace: NAMESPACE

--- a/charts/snyk-broker/tests/__snapshot__/broker_deployment_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/broker_deployment_test.yaml.snap
@@ -7,7 +7,7 @@ HA mode on:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.3
+        helm.sh/chart: snyk-broker-2.6.4
       name: github-com-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -107,7 +107,7 @@ HA mode on:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.3
+        helm.sh/chart: snyk-broker-2.6.4
       name: github-com-broker-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -134,7 +134,7 @@ HA mode on:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.3
+        helm.sh/chart: snyk-broker-2.6.4
       name: snyk-broker-RELEASE-NAME
       namespace: NAMESPACE
 HA mode on with 4 replicas:
@@ -146,7 +146,7 @@ HA mode on with 4 replicas:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.3
+        helm.sh/chart: snyk-broker-2.6.4
       name: github-com-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -246,7 +246,7 @@ HA mode on with 4 replicas:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.3
+        helm.sh/chart: snyk-broker-2.6.4
       name: github-com-broker-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -273,7 +273,7 @@ HA mode on with 4 replicas:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.3
+        helm.sh/chart: snyk-broker-2.6.4
       name: snyk-broker-RELEASE-NAME
       namespace: NAMESPACE
 HTTPS enabled:
@@ -285,7 +285,7 @@ HTTPS enabled:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.3
+        helm.sh/chart: snyk-broker-2.6.4
       name: github-com-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -393,7 +393,7 @@ HTTPS enabled:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.3
+        helm.sh/chart: snyk-broker-2.6.4
       name: github-com-broker-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -429,7 +429,7 @@ HTTPS enabled:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.3
+        helm.sh/chart: snyk-broker-2.6.4
       name: snyk-broker-RELEASE-NAME
       namespace: NAMESPACE
 default values:
@@ -441,7 +441,7 @@ default values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.3
+        helm.sh/chart: snyk-broker-2.6.4
       name: github-com-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -539,7 +539,7 @@ default values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.3
+        helm.sh/chart: snyk-broker-2.6.4
       name: github-com-broker-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -566,7 +566,7 @@ default values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.3
+        helm.sh/chart: snyk-broker-2.6.4
       name: snyk-broker-RELEASE-NAME
       namespace: NAMESPACE
 preflight checks off:
@@ -578,7 +578,7 @@ preflight checks off:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.3
+        helm.sh/chart: snyk-broker-2.6.4
       name: github-com-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -678,7 +678,7 @@ preflight checks off:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.3
+        helm.sh/chart: snyk-broker-2.6.4
       name: github-com-broker-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -705,6 +705,6 @@ preflight checks off:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.3
+        helm.sh/chart: snyk-broker-2.6.4
       name: snyk-broker-RELEASE-NAME
       namespace: NAMESPACE

--- a/charts/snyk-broker/tests/__snapshot__/cra_deployment_digitalocean_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/cra_deployment_digitalocean_test.yaml.snap
@@ -7,7 +7,7 @@ default values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.3
+        helm.sh/chart: snyk-broker-2.6.4
       name: container-registry-agent-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -157,7 +157,7 @@ default values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.3
+        helm.sh/chart: snyk-broker-2.6.4
       name: cra-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:

--- a/charts/snyk-broker/tests/__snapshot__/cra_deployment_disablesuffixes_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/cra_deployment_disablesuffixes_test.yaml.snap
@@ -7,7 +7,7 @@ default values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.6.3
+        helm.sh/chart: snyk-broker-2.6.4
       name: container-registry-agent-broker
       namespace: NAMESPACE
     spec:
@@ -156,7 +156,7 @@ default values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.6.3
+        helm.sh/chart: snyk-broker-2.6.4
       name: cra-service
       namespace: NAMESPACE
     spec:

--- a/charts/snyk-broker/tests/__snapshot__/cra_deployment_harbor_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/cra_deployment_harbor_test.yaml.snap
@@ -7,7 +7,7 @@ default values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.3
+        helm.sh/chart: snyk-broker-2.6.4
       name: container-registry-agent-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -159,7 +159,7 @@ default values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.3
+        helm.sh/chart: snyk-broker-2.6.4
       name: cra-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:

--- a/charts/snyk-broker/tests/__snapshot__/cra_deployment_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/cra_deployment_test.yaml.snap
@@ -7,7 +7,7 @@ default values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.3
+        helm.sh/chart: snyk-broker-2.6.4
       name: container-registry-agent-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -156,7 +156,7 @@ default values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.3
+        helm.sh/chart: snyk-broker-2.6.4
       name: cra-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:

--- a/charts/snyk-broker/tests/broker_deployment_artifactory_test.yaml
+++ b/charts/snyk-broker/tests/broker_deployment_artifactory_test.yaml
@@ -1,0 +1,17 @@
+suite: broker deployment (artifactory)
+templates:
+  - broker_deployment.yaml
+  - broker_service.yaml
+  - secrets.yaml
+  - serviceaccount.yaml
+values:
+  - ./fixtures/default_values.yaml
+
+tests:
+  - it: should render artifactoryUrl and brokerClientValidationUrl as secrets
+    set:
+      scmType: artifactory
+      artifactoryUrl: username:password@your-domain.com/artifactory
+      brokerClientValidationUrl: https://username:password@your-domain.com/artifactory/api/system/ping
+    asserts:
+      - matchSnapshot: {}


### PR DESCRIPTION
This PR creates a secret if `scmType: artifactory` because ARTIFACTORY_URL may contain `user:password` in URL as Basic auth.
Following secrets will be created because they may contain credentials:
- artifactory-url
- artifactory-broker-client-validation-url

Additionally BROKER_CLIENT_URL will be set for consistency with other scmTypes.