### PR TITLE
fix: nexus broker client validation url as secret

### DIFF
--- a/charts/snyk-broker/Chart.yaml
+++ b/charts/snyk-broker/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: snyk-broker
-version: 2.6.4
+version: 2.6.5
 description: A Helm chart for Kubernetes
 type: application

--- a/charts/snyk-broker/templates/broker_deployment.yaml
+++ b/charts/snyk-broker/templates/broker_deployment.yaml
@@ -279,7 +279,10 @@ spec:
                   name: {{ .Values.scmType }}-nexus-url{{if not .Values.disableSuffixes }}-{{ .Release.Name }}{{ end }}
                   key: "{{ .Values.scmType}}-nexus-url"
             - name: BROKER_CLIENT_VALIDATION_URL
-              value: {{ .Values.brokerClientValidationUrl }}
+              valueFrom:
+                secretKeyRef:
+                  name: nexus-broker-client-validation-url{{if not .Values.disableSuffixes }}-{{ .Release.Name }}{{ end }}
+                  key: "nexus-broker-client-validation-url"
             - name: PORT
               value: {{ .Values.deployment.container.containerPort | squote }}
           {{- end }}

--- a/charts/snyk-broker/templates/secrets.yaml
+++ b/charts/snyk-broker/templates/secrets.yaml
@@ -138,6 +138,18 @@ data:
   "nexus-nexus-url": {{ .Values.nexusUrl | b64enc | quote }}
 ---
 {{- end}}
+{{ if or (.Values.baseNexusUrl) (.Values.nexusUrl) }}
+  {{- if .Values.brokerClientValidationUrl }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: nexus-broker-client-validation-url{{if not .Values.disableSuffixes }}-{{ .Release.Name }}{{ end }}
+type: Opaque
+stringData:
+  nexus-broker-client-validation-url: {{ .Values.brokerClientValidationUrl | quote }}
+---
+  {{- end }}
+{{- end }}
 {{- if and (.Values.httpsCert) (.Values.httpsKey) }}
 apiVersion: v1
 kind: Secret

--- a/charts/snyk-broker/tests/__snapshot__/broker_cra_deployment_disablesuffixes_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/broker_cra_deployment_disablesuffixes_test.yaml.snap
@@ -7,7 +7,7 @@ with CRA:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.4
+        helm.sh/chart: snyk-broker-2.6.5
       name: container-registry-agent-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -108,7 +108,7 @@ with CRA:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.4
+        helm.sh/chart: snyk-broker-2.6.5
       name: container-registry-agent-broker-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -135,6 +135,6 @@ with CRA:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.4
+        helm.sh/chart: snyk-broker-2.6.5
       name: snyk-broker-RELEASE-NAME
       namespace: NAMESPACE

--- a/charts/snyk-broker/tests/__snapshot__/broker_cra_deployment_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/broker_cra_deployment_test.yaml.snap
@@ -7,7 +7,7 @@ with CRA:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.4
+        helm.sh/chart: snyk-broker-2.6.5
       name: container-registry-agent-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -108,7 +108,7 @@ with CRA:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.4
+        helm.sh/chart: snyk-broker-2.6.5
       name: container-registry-agent-broker-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -135,6 +135,6 @@ with CRA:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.4
+        helm.sh/chart: snyk-broker-2.6.5
       name: snyk-broker-RELEASE-NAME
       namespace: NAMESPACE

--- a/charts/snyk-broker/tests/__snapshot__/broker_deployment_apprisk_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/broker_deployment_apprisk_test.yaml.snap
@@ -7,7 +7,7 @@ apprisk enabled:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.4
+        helm.sh/chart: snyk-broker-2.6.5
       name: github-com-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -107,7 +107,7 @@ apprisk enabled:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.4
+        helm.sh/chart: snyk-broker-2.6.5
       name: github-com-broker-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -134,6 +134,6 @@ apprisk enabled:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.4
+        helm.sh/chart: snyk-broker-2.6.5
       name: snyk-broker-RELEASE-NAME
       namespace: NAMESPACE

--- a/charts/snyk-broker/tests/__snapshot__/broker_deployment_artifactory_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/broker_deployment_artifactory_test.yaml.snap
@@ -7,7 +7,7 @@ should render artifactoryUrl and brokerClientValidationUrl as secrets:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.4
+        helm.sh/chart: snyk-broker-2.6.5
       name: artifactory-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -106,7 +106,7 @@ should render artifactoryUrl and brokerClientValidationUrl as secrets:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.4
+        helm.sh/chart: snyk-broker-2.6.5
       name: artifactory-broker-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -149,6 +149,6 @@ should render artifactoryUrl and brokerClientValidationUrl as secrets:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.4
+        helm.sh/chart: snyk-broker-2.6.5
       name: snyk-broker-RELEASE-NAME
       namespace: NAMESPACE

--- a/charts/snyk-broker/tests/__snapshot__/broker_deployment_configmap_disablesuffixes_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/broker_deployment_configmap_disablesuffixes_test.yaml.snap
@@ -7,7 +7,7 @@ cacert:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.6.4
+        helm.sh/chart: snyk-broker-2.6.5
       name: github-com-broker
       namespace: NAMESPACE
     spec:
@@ -115,7 +115,7 @@ cacert:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.6.4
+        helm.sh/chart: snyk-broker-2.6.5
       name: github-com-broker-service
       namespace: NAMESPACE
     spec:
@@ -157,7 +157,7 @@ cacert:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.6.4
+        helm.sh/chart: snyk-broker-2.6.5
       name: RELEASE-NAME-snyk-broker-cacert-configmap
       namespace: NAMESPACE
   4: |
@@ -176,7 +176,7 @@ cacert:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.6.4
+        helm.sh/chart: snyk-broker-2.6.5
       name: snyk-broker
       namespace: NAMESPACE
 cacertfile:
@@ -188,7 +188,7 @@ cacertfile:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.6.4
+        helm.sh/chart: snyk-broker-2.6.5
       name: github-com-broker
       namespace: NAMESPACE
     spec:
@@ -296,7 +296,7 @@ cacertfile:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.6.4
+        helm.sh/chart: snyk-broker-2.6.5
       name: github-com-broker-service
       namespace: NAMESPACE
     spec:
@@ -317,7 +317,7 @@ cacertfile:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.6.4
+        helm.sh/chart: snyk-broker-2.6.5
       name: RELEASE-NAME-snyk-broker-cacert-configmap
       namespace: NAMESPACE
   4: |
@@ -336,6 +336,6 @@ cacertfile:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.6.4
+        helm.sh/chart: snyk-broker-2.6.5
       name: snyk-broker
       namespace: NAMESPACE

--- a/charts/snyk-broker/tests/__snapshot__/broker_deployment_configmap_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/broker_deployment_configmap_test.yaml.snap
@@ -7,7 +7,7 @@ cacert:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.4
+        helm.sh/chart: snyk-broker-2.6.5
       name: github-com-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -115,7 +115,7 @@ cacert:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.4
+        helm.sh/chart: snyk-broker-2.6.5
       name: github-com-broker-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -157,7 +157,7 @@ cacert:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.4
+        helm.sh/chart: snyk-broker-2.6.5
       name: RELEASE-NAME-snyk-broker-cacert-configmap-RELEASE-NAME
       namespace: NAMESPACE
   4: |
@@ -176,7 +176,7 @@ cacert:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.4
+        helm.sh/chart: snyk-broker-2.6.5
       name: snyk-broker-RELEASE-NAME
       namespace: NAMESPACE
 cacertfile:
@@ -188,7 +188,7 @@ cacertfile:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.4
+        helm.sh/chart: snyk-broker-2.6.5
       name: github-com-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -296,7 +296,7 @@ cacertfile:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.4
+        helm.sh/chart: snyk-broker-2.6.5
       name: github-com-broker-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -317,7 +317,7 @@ cacertfile:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.4
+        helm.sh/chart: snyk-broker-2.6.5
       name: RELEASE-NAME-snyk-broker-cacert-configmap-RELEASE-NAME
       namespace: NAMESPACE
   4: |
@@ -336,6 +336,6 @@ cacertfile:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.4
+        helm.sh/chart: snyk-broker-2.6.5
       name: snyk-broker-RELEASE-NAME
       namespace: NAMESPACE

--- a/charts/snyk-broker/tests/__snapshot__/broker_deployment_customaccept_disablesuffixes_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/broker_deployment_customaccept_disablesuffixes_test.yaml.snap
@@ -9,7 +9,7 @@ customaccept values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.6.4
+        helm.sh/chart: snyk-broker-2.6.5
       name: RELEASE-NAME-snyk-broker-accept-configmap
       namespace: NAMESPACE
   2: |
@@ -20,7 +20,7 @@ customaccept values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.6.4
+        helm.sh/chart: snyk-broker-2.6.5
       name: github-com-broker
       namespace: NAMESPACE
     spec:
@@ -122,7 +122,7 @@ customaccept values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.6.4
+        helm.sh/chart: snyk-broker-2.6.5
       name: github-com-broker-service
       namespace: NAMESPACE
     spec:
@@ -149,6 +149,6 @@ customaccept values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.6.4
+        helm.sh/chart: snyk-broker-2.6.5
       name: snyk-broker
       namespace: NAMESPACE

--- a/charts/snyk-broker/tests/__snapshot__/broker_deployment_customaccept_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/broker_deployment_customaccept_test.yaml.snap
@@ -9,7 +9,7 @@ customaccept values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.4
+        helm.sh/chart: snyk-broker-2.6.5
       name: RELEASE-NAME-snyk-broker-accept-configmap-RELEASE-NAME
       namespace: NAMESPACE
   2: |
@@ -20,7 +20,7 @@ customaccept values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.4
+        helm.sh/chart: snyk-broker-2.6.5
       name: github-com-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -122,7 +122,7 @@ customaccept values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.4
+        helm.sh/chart: snyk-broker-2.6.5
       name: github-com-broker-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -149,6 +149,6 @@ customaccept values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.4
+        helm.sh/chart: snyk-broker-2.6.5
       name: snyk-broker-RELEASE-NAME
       namespace: NAMESPACE

--- a/charts/snyk-broker/tests/__snapshot__/broker_deployment_disablesuffixes_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/broker_deployment_disablesuffixes_test.yaml.snap
@@ -7,7 +7,7 @@ HA mode on:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.6.4
+        helm.sh/chart: snyk-broker-2.6.5
       name: github-com-broker
       namespace: NAMESPACE
     spec:
@@ -107,7 +107,7 @@ HA mode on:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.6.4
+        helm.sh/chart: snyk-broker-2.6.5
       name: github-com-broker-service
       namespace: NAMESPACE
     spec:
@@ -134,7 +134,7 @@ HA mode on:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.6.4
+        helm.sh/chart: snyk-broker-2.6.5
       name: snyk-broker
       namespace: NAMESPACE
 HA mode on with 4 replicas:
@@ -146,7 +146,7 @@ HA mode on with 4 replicas:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.6.4
+        helm.sh/chart: snyk-broker-2.6.5
       name: github-com-broker
       namespace: NAMESPACE
     spec:
@@ -246,7 +246,7 @@ HA mode on with 4 replicas:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.6.4
+        helm.sh/chart: snyk-broker-2.6.5
       name: github-com-broker-service
       namespace: NAMESPACE
     spec:
@@ -273,7 +273,7 @@ HA mode on with 4 replicas:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.6.4
+        helm.sh/chart: snyk-broker-2.6.5
       name: snyk-broker
       namespace: NAMESPACE
 default values:
@@ -285,7 +285,7 @@ default values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.6.4
+        helm.sh/chart: snyk-broker-2.6.5
       name: github-com-broker
       namespace: NAMESPACE
     spec:
@@ -383,7 +383,7 @@ default values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.6.4
+        helm.sh/chart: snyk-broker-2.6.5
       name: github-com-broker-service
       namespace: NAMESPACE
     spec:
@@ -410,7 +410,7 @@ default values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.6.4
+        helm.sh/chart: snyk-broker-2.6.5
       name: snyk-broker
       namespace: NAMESPACE
 preflight checks off:
@@ -422,7 +422,7 @@ preflight checks off:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.6.4
+        helm.sh/chart: snyk-broker-2.6.5
       name: github-com-broker
       namespace: NAMESPACE
     spec:
@@ -522,7 +522,7 @@ preflight checks off:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.6.4
+        helm.sh/chart: snyk-broker-2.6.5
       name: github-com-broker-service
       namespace: NAMESPACE
     spec:
@@ -549,6 +549,6 @@ preflight checks off:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.6.4
+        helm.sh/chart: snyk-broker-2.6.5
       name: snyk-broker
       namespace: NAMESPACE

--- a/charts/snyk-broker/tests/__snapshot__/broker_deployment_ingress_disablesuffixes_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/broker_deployment_ingress_disablesuffixes_test.yaml.snap
@@ -7,7 +7,7 @@ ingress:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.6.4
+        helm.sh/chart: snyk-broker-2.6.5
       name: github-com-broker
       namespace: NAMESPACE
     spec:
@@ -105,7 +105,7 @@ ingress:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.6.4
+        helm.sh/chart: snyk-broker-2.6.5
       name: RELEASE-NAME-snyk-broker
       namespace: NAMESPACE
     spec:
@@ -125,7 +125,7 @@ ingress:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.6.4
+        helm.sh/chart: snyk-broker-2.6.5
       name: github-com-broker-service
       namespace: NAMESPACE
     spec:
@@ -152,6 +152,6 @@ ingress:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.6.4
+        helm.sh/chart: snyk-broker-2.6.5
       name: snyk-broker
       namespace: NAMESPACE

--- a/charts/snyk-broker/tests/__snapshot__/broker_deployment_ingress_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/broker_deployment_ingress_test.yaml.snap
@@ -7,7 +7,7 @@ ingress:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.4
+        helm.sh/chart: snyk-broker-2.6.5
       name: github-com-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -105,7 +105,7 @@ ingress:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.4
+        helm.sh/chart: snyk-broker-2.6.5
       name: RELEASE-NAME-snyk-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -125,7 +125,7 @@ ingress:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.4
+        helm.sh/chart: snyk-broker-2.6.5
       name: github-com-broker-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -152,6 +152,6 @@ ingress:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.4
+        helm.sh/chart: snyk-broker-2.6.5
       name: snyk-broker-RELEASE-NAME
       namespace: NAMESPACE

--- a/charts/snyk-broker/tests/__snapshot__/broker_deployment_nexus_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/broker_deployment_nexus_test.yaml.snap
@@ -1,0 +1,165 @@
+should render render nexusUrl, baseNexusUrl and brokerClientValidationUrl as secrets:
+  1: |
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      labels:
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: snyk-broker-RELEASE-NAME
+        helm.sh/chart: snyk-broker-0.0.0
+      name: nexus-broker-RELEASE-NAME
+      namespace: NAMESPACE
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app.kubernetes.io/instance: RELEASE-NAME
+          app.kubernetes.io/name: snyk-broker-RELEASE-NAME
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/name: snyk-broker-RELEASE-NAME
+        spec:
+          containers:
+            - env:
+                - name: BROKER_SERVER_URL
+                  value: https://broker.test.snyk.io
+                - name: BROKER_HEALTHCHECK_PATH
+                  value: /healthcheck
+                - name: BROKER_SYSTEMCHECK_PATH
+                  value: /systemcheck
+                - name: BROKER_TOKEN
+                  valueFrom:
+                    secretKeyRef:
+                      key: nexus-broker-token-key
+                      name: nexus-broker-token-RELEASE-NAME
+                - name: BASE_NEXUS_URL
+                  valueFrom:
+                    secretKeyRef:
+                      key: nexus-base-nexus-url
+                      name: nexus-base-nexus-url-RELEASE-NAME
+                - name: NEXUS_URL
+                  valueFrom:
+                    secretKeyRef:
+                      key: nexus-nexus-url
+                      name: nexus-nexus-url-RELEASE-NAME
+                - name: BROKER_CLIENT_VALIDATION_URL
+                  valueFrom:
+                    secretKeyRef:
+                      key: nexus-broker-client-validation-url
+                      name: nexus-broker-client-validation-url-RELEASE-NAME
+                - name: PORT
+                  value: "8000"
+                - name: LOG_LEVEL
+                  value: info
+                - name: LOG_ENABLE_BODY
+                  value: "false"
+                - name: BROKER_DISPATCHER_BASE_URL
+                  value: https://api.test.snyk.io
+              image: snyk/broker:nexus
+              imagePullPolicy: Always
+              livenessProbe:
+                failureThreshold: 3
+                httpGet:
+                  path: /healthcheck
+                  port: 8000
+                  scheme: HTTP
+                initialDelaySeconds: 3
+                periodSeconds: 10
+                timeoutSeconds: 1
+              name: nexus-broker-RELEASE-NAME
+              ports:
+                - containerPort: 8000
+                  name: http
+              readinessProbe:
+                failureThreshold: 3
+                httpGet:
+                  path: /healthcheck
+                  port: 8000
+                  scheme: HTTP
+                initialDelaySeconds: 3
+                periodSeconds: 10
+                timeoutSeconds: 1
+              resources:
+                limits:
+                  cpu: 1
+                  memory: 256Mi
+                requests:
+                  cpu: 1
+                  memory: 256Mi
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop:
+                    - ALL
+                readOnlyRootFilesystem: true
+                runAsNonRoot: true
+                runAsUser: 1000
+              volumeMounts: null
+          securityContext: {}
+          serviceAccountName: snyk-broker-RELEASE-NAME
+          volumes: null
+  2: |
+    apiVersion: v1
+    kind: Service
+    metadata:
+      labels:
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: snyk-broker-RELEASE-NAME
+        helm.sh/chart: snyk-broker-0.0.0
+      name: nexus-broker-service-RELEASE-NAME
+      namespace: NAMESPACE
+    spec:
+      ports:
+        - port: 8000
+          targetPort: 8000
+      selector:
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/name: snyk-broker-RELEASE-NAME
+      type: ClusterIP
+  3: |
+    apiVersion: v1
+    data:
+      nexus-broker-token-key: MTIz
+    kind: Secret
+    metadata:
+      name: nexus-broker-token-RELEASE-NAME
+    type: Opaque
+  4: |
+    apiVersion: v1
+    data:
+      nexus-base-nexus-url: aHR0cHM6Ly91c2VybmFtZTpwYXNzd29yZEB5b3VyLWRvbWFpbi5jb20=
+    kind: Secret
+    metadata:
+      name: nexus-base-nexus-url-RELEASE-NAME
+    type: Opaque
+  5: |
+    apiVersion: v1
+    data:
+      nexus-nexus-url: aHR0cHM6Ly91c2VybmFtZTpwYXNzd29yZEB5b3VyLWRvbWFpbi5jb20vcmVwb3NpdG9yeQ==
+    kind: Secret
+    metadata:
+      name: nexus-nexus-url-RELEASE-NAME
+    type: Opaque
+  6: |
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: nexus-broker-client-validation-url-RELEASE-NAME
+    stringData:
+      nexus-broker-client-validation-url: https://username:password@your-domain.com/service/rest/v1/status/check
+    type: Opaque
+  7: |
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      labels:
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: snyk-broker-RELEASE-NAME
+        helm.sh/chart: snyk-broker-0.0.0
+      name: snyk-broker-RELEASE-NAME
+      namespace: NAMESPACE

--- a/charts/snyk-broker/tests/__snapshot__/broker_deployment_scm_token_pool_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/broker_deployment_scm_token_pool_test.yaml.snap
@@ -7,7 +7,7 @@ github token pool configured:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.4
+        helm.sh/chart: snyk-broker-2.6.5
       name: github-com-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -110,7 +110,7 @@ github token pool configured:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.4
+        helm.sh/chart: snyk-broker-2.6.5
       name: github-com-broker-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -145,7 +145,7 @@ github token pool configured:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.4
+        helm.sh/chart: snyk-broker-2.6.5
       name: snyk-broker-RELEASE-NAME
       namespace: NAMESPACE
 github token pool configured with enabled useExternalSecretScmTokenPool:
@@ -157,7 +157,7 @@ github token pool configured with enabled useExternalSecretScmTokenPool:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.4
+        helm.sh/chart: snyk-broker-2.6.5
       name: github-com-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -255,7 +255,7 @@ github token pool configured with enabled useExternalSecretScmTokenPool:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.4
+        helm.sh/chart: snyk-broker-2.6.5
       name: github-com-broker-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -282,7 +282,7 @@ github token pool configured with enabled useExternalSecretScmTokenPool:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.4
+        helm.sh/chart: snyk-broker-2.6.5
       name: snyk-broker-RELEASE-NAME
       namespace: NAMESPACE
 gitlab token pool configured:
@@ -294,7 +294,7 @@ gitlab token pool configured:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.4
+        helm.sh/chart: snyk-broker-2.6.5
       name: gitlab-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -399,7 +399,7 @@ gitlab token pool configured:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.4
+        helm.sh/chart: snyk-broker-2.6.5
       name: gitlab-broker-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -434,6 +434,6 @@ gitlab token pool configured:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.4
+        helm.sh/chart: snyk-broker-2.6.5
       name: snyk-broker-RELEASE-NAME
       namespace: NAMESPACE

--- a/charts/snyk-broker/tests/__snapshot__/broker_deployment_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/broker_deployment_test.yaml.snap
@@ -7,7 +7,7 @@ HA mode on:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.4
+        helm.sh/chart: snyk-broker-2.6.5
       name: github-com-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -107,7 +107,7 @@ HA mode on:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.4
+        helm.sh/chart: snyk-broker-2.6.5
       name: github-com-broker-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -134,7 +134,7 @@ HA mode on:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.4
+        helm.sh/chart: snyk-broker-2.6.5
       name: snyk-broker-RELEASE-NAME
       namespace: NAMESPACE
 HA mode on with 4 replicas:
@@ -146,7 +146,7 @@ HA mode on with 4 replicas:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.4
+        helm.sh/chart: snyk-broker-2.6.5
       name: github-com-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -246,7 +246,7 @@ HA mode on with 4 replicas:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.4
+        helm.sh/chart: snyk-broker-2.6.5
       name: github-com-broker-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -273,7 +273,7 @@ HA mode on with 4 replicas:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.4
+        helm.sh/chart: snyk-broker-2.6.5
       name: snyk-broker-RELEASE-NAME
       namespace: NAMESPACE
 HTTPS enabled:
@@ -285,7 +285,7 @@ HTTPS enabled:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.4
+        helm.sh/chart: snyk-broker-2.6.5
       name: github-com-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -393,7 +393,7 @@ HTTPS enabled:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.4
+        helm.sh/chart: snyk-broker-2.6.5
       name: github-com-broker-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -429,7 +429,7 @@ HTTPS enabled:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.4
+        helm.sh/chart: snyk-broker-2.6.5
       name: snyk-broker-RELEASE-NAME
       namespace: NAMESPACE
 default values:
@@ -441,7 +441,7 @@ default values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.4
+        helm.sh/chart: snyk-broker-2.6.5
       name: github-com-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -539,7 +539,7 @@ default values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.4
+        helm.sh/chart: snyk-broker-2.6.5
       name: github-com-broker-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -566,7 +566,7 @@ default values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.4
+        helm.sh/chart: snyk-broker-2.6.5
       name: snyk-broker-RELEASE-NAME
       namespace: NAMESPACE
 preflight checks off:
@@ -578,7 +578,7 @@ preflight checks off:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.4
+        helm.sh/chart: snyk-broker-2.6.5
       name: github-com-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -678,7 +678,7 @@ preflight checks off:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.4
+        helm.sh/chart: snyk-broker-2.6.5
       name: github-com-broker-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -705,6 +705,6 @@ preflight checks off:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.4
+        helm.sh/chart: snyk-broker-2.6.5
       name: snyk-broker-RELEASE-NAME
       namespace: NAMESPACE

--- a/charts/snyk-broker/tests/__snapshot__/cra_deployment_digitalocean_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/cra_deployment_digitalocean_test.yaml.snap
@@ -7,7 +7,7 @@ default values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.4
+        helm.sh/chart: snyk-broker-2.6.5
       name: container-registry-agent-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -157,7 +157,7 @@ default values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.4
+        helm.sh/chart: snyk-broker-2.6.5
       name: cra-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:

--- a/charts/snyk-broker/tests/__snapshot__/cra_deployment_disablesuffixes_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/cra_deployment_disablesuffixes_test.yaml.snap
@@ -7,7 +7,7 @@ default values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.6.4
+        helm.sh/chart: snyk-broker-2.6.5
       name: container-registry-agent-broker
       namespace: NAMESPACE
     spec:
@@ -156,7 +156,7 @@ default values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.6.4
+        helm.sh/chart: snyk-broker-2.6.5
       name: cra-service
       namespace: NAMESPACE
     spec:

--- a/charts/snyk-broker/tests/__snapshot__/cra_deployment_harbor_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/cra_deployment_harbor_test.yaml.snap
@@ -7,7 +7,7 @@ default values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.4
+        helm.sh/chart: snyk-broker-2.6.5
       name: container-registry-agent-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -159,7 +159,7 @@ default values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.4
+        helm.sh/chart: snyk-broker-2.6.5
       name: cra-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:

--- a/charts/snyk-broker/tests/__snapshot__/cra_deployment_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/cra_deployment_test.yaml.snap
@@ -7,7 +7,7 @@ default values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.4
+        helm.sh/chart: snyk-broker-2.6.5
       name: container-registry-agent-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -156,7 +156,7 @@ default values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.4
+        helm.sh/chart: snyk-broker-2.6.5
       name: cra-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:

--- a/charts/snyk-broker/tests/broker_deployment_nexus_test.yaml
+++ b/charts/snyk-broker/tests/broker_deployment_nexus_test.yaml
@@ -1,0 +1,102 @@
+suite: broker deployment (nexus)
+values:
+  - ./fixtures/default_values.yaml
+
+tests:
+  - it: should create secret if brokerClientValidationUrl, baseNexusUrl and nexusUrl are defined
+    chart:
+      version: 0.0.0
+    template: secrets.yaml
+
+    set:
+      scmType: nexus
+      baseNexusUrl: https://username:password@your-domain.com
+      nexusUrl: https://username:password@your-domain.com/repository
+      brokerClientValidationUrl: https://username:password@your-domain.com/service/rest/v1/status/check
+      disableSuffixes: true
+    documentIndex: 3
+
+    asserts:
+      - containsDocument:
+          apiVersion: v1
+          kind: Secret
+          name: nexus-broker-client-validation-url
+      - equal:
+          path: stringData.nexus-broker-client-validation-url
+          value: https://username:password@your-domain.com/service/rest/v1/status/check
+
+  - it: should create secret if brokerClientValidationUrl and nexusUrl are defined
+    chart:
+      version: 0.0.0
+    template: secrets.yaml
+
+    set:
+      scmType: nexus
+      nexusUrl: https://username:password@your-domain.com/repository
+      brokerClientValidationUrl: https://username:password@your-domain.com/service/rest/v1/status/check
+      disableSuffixes: true
+    documentIndex: 2
+
+    asserts:
+      - containsDocument:
+          apiVersion: v1
+          kind: Secret
+          name: nexus-broker-client-validation-url
+      - equal:
+          path: stringData.nexus-broker-client-validation-url
+          value: https://username:password@your-domain.com/service/rest/v1/status/check
+
+  - it: should create secret if brokerClientValidationUrl and baseNexusUrl are defined
+    chart:
+      version: 0.0.0
+    template: secrets.yaml
+
+    set:
+      scmType: nexus
+      baseNexusUrl: https://username:password@your-domain.com
+      brokerClientValidationUrl: https://username:password@your-domain.com/service/rest/v1/status/check
+      disableSuffixes: true
+    documentIndex: 2
+
+    asserts:
+      - containsDocument:
+          apiVersion: v1
+          kind: Secret
+          name: nexus-broker-client-validation-url
+      - equal:
+          path: stringData.nexus-broker-client-validation-url
+          value: https://username:password@your-domain.com/service/rest/v1/status/check
+
+  - it: should not create secret for brokerClientValidationUrl if value is empty
+    chart:
+      version: 0.0.0
+    template: secrets.yaml
+
+    set:
+      scmType: nexus
+      nexusUrl: https://username:password@your-domain.com/repository
+      baseNexusUrl: https://username:password@your-domain.com
+      disableSuffixes: true
+
+    asserts:
+      - notEqual:
+          path: metadata.name
+          value: nexus-broker-client-validation-url
+
+  - it: should render render nexusUrl, baseNexusUrl and brokerClientValidationUrl as secrets
+    chart:
+      version: 0.0.0
+    templates:
+      - broker_deployment.yaml
+      - broker_service.yaml
+      - secrets.yaml
+      - serviceaccount.yaml
+
+    set:
+      scmType: nexus
+      baseNexusUrl: https://username:password@your-domain.com
+      nexusUrl: https://username:password@your-domain.com/repository
+      brokerClientValidationUrl: https://username:password@your-domain.com/service/rest/v1/status/check
+
+    asserts:
+      - matchSnapshot: {}


### PR DESCRIPTION
This PR creates a secret for **brokerClientValidationUrl** if it's defined for `scmType: nexus/nexus2`, because URL may contain *username:password*.

Additionally we specify `chart.version` in broker_deployment_nexus_test.yaml` to overcome the issues with bumping snapshots because of new releases.
> action run to confirm: https://github.com/snyk/snyk-broker-helm/actions/runs/8638297257/job/23682434195#step:4:763