### PR TITLE
chore: specify chart version for tests snapshots

### DIFF
--- a/charts/snyk-broker/tests/__snapshot__/broker_cra_deployment_disablesuffixes_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/broker_cra_deployment_disablesuffixes_test.yaml.snap
@@ -7,7 +7,7 @@ with CRA:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.5
+        helm.sh/chart: snyk-broker-0.0.0
       name: container-registry-agent-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -108,7 +108,7 @@ with CRA:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.5
+        helm.sh/chart: snyk-broker-0.0.0
       name: container-registry-agent-broker-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -135,6 +135,6 @@ with CRA:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.5
+        helm.sh/chart: snyk-broker-0.0.0
       name: snyk-broker-RELEASE-NAME
       namespace: NAMESPACE

--- a/charts/snyk-broker/tests/__snapshot__/broker_cra_deployment_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/broker_cra_deployment_test.yaml.snap
@@ -7,7 +7,7 @@ with CRA:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.5
+        helm.sh/chart: snyk-broker-0.0.0
       name: container-registry-agent-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -108,7 +108,7 @@ with CRA:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.5
+        helm.sh/chart: snyk-broker-0.0.0
       name: container-registry-agent-broker-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -135,6 +135,6 @@ with CRA:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.5
+        helm.sh/chart: snyk-broker-0.0.0
       name: snyk-broker-RELEASE-NAME
       namespace: NAMESPACE

--- a/charts/snyk-broker/tests/__snapshot__/broker_deployment_apprisk_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/broker_deployment_apprisk_test.yaml.snap
@@ -7,7 +7,7 @@ apprisk enabled:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.5
+        helm.sh/chart: snyk-broker-0.0.0
       name: github-com-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -107,7 +107,7 @@ apprisk enabled:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.5
+        helm.sh/chart: snyk-broker-0.0.0
       name: github-com-broker-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -134,6 +134,6 @@ apprisk enabled:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.5
+        helm.sh/chart: snyk-broker-0.0.0
       name: snyk-broker-RELEASE-NAME
       namespace: NAMESPACE

--- a/charts/snyk-broker/tests/__snapshot__/broker_deployment_artifactory_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/broker_deployment_artifactory_test.yaml.snap
@@ -7,7 +7,7 @@ should render artifactoryUrl and brokerClientValidationUrl as secrets:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.5
+        helm.sh/chart: snyk-broker-0.0.0
       name: artifactory-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -106,7 +106,7 @@ should render artifactoryUrl and brokerClientValidationUrl as secrets:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.5
+        helm.sh/chart: snyk-broker-0.0.0
       name: artifactory-broker-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -149,6 +149,6 @@ should render artifactoryUrl and brokerClientValidationUrl as secrets:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.5
+        helm.sh/chart: snyk-broker-0.0.0
       name: snyk-broker-RELEASE-NAME
       namespace: NAMESPACE

--- a/charts/snyk-broker/tests/__snapshot__/broker_deployment_configmap_disablesuffixes_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/broker_deployment_configmap_disablesuffixes_test.yaml.snap
@@ -7,7 +7,7 @@ cacert:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.6.5
+        helm.sh/chart: snyk-broker-0.0.0
       name: github-com-broker
       namespace: NAMESPACE
     spec:
@@ -115,7 +115,7 @@ cacert:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.6.5
+        helm.sh/chart: snyk-broker-0.0.0
       name: github-com-broker-service
       namespace: NAMESPACE
     spec:
@@ -157,7 +157,7 @@ cacert:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.6.5
+        helm.sh/chart: snyk-broker-0.0.0
       name: RELEASE-NAME-snyk-broker-cacert-configmap
       namespace: NAMESPACE
   4: |
@@ -176,7 +176,7 @@ cacert:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.6.5
+        helm.sh/chart: snyk-broker-0.0.0
       name: snyk-broker
       namespace: NAMESPACE
 cacertfile:
@@ -188,7 +188,7 @@ cacertfile:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.6.5
+        helm.sh/chart: snyk-broker-0.0.0
       name: github-com-broker
       namespace: NAMESPACE
     spec:
@@ -296,7 +296,7 @@ cacertfile:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.6.5
+        helm.sh/chart: snyk-broker-0.0.0
       name: github-com-broker-service
       namespace: NAMESPACE
     spec:
@@ -317,7 +317,7 @@ cacertfile:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.6.5
+        helm.sh/chart: snyk-broker-0.0.0
       name: RELEASE-NAME-snyk-broker-cacert-configmap
       namespace: NAMESPACE
   4: |
@@ -336,6 +336,6 @@ cacertfile:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.6.5
+        helm.sh/chart: snyk-broker-0.0.0
       name: snyk-broker
       namespace: NAMESPACE

--- a/charts/snyk-broker/tests/__snapshot__/broker_deployment_configmap_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/broker_deployment_configmap_test.yaml.snap
@@ -7,7 +7,7 @@ cacert:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.5
+        helm.sh/chart: snyk-broker-0.0.0
       name: github-com-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -115,7 +115,7 @@ cacert:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.5
+        helm.sh/chart: snyk-broker-0.0.0
       name: github-com-broker-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -157,7 +157,7 @@ cacert:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.5
+        helm.sh/chart: snyk-broker-0.0.0
       name: RELEASE-NAME-snyk-broker-cacert-configmap-RELEASE-NAME
       namespace: NAMESPACE
   4: |
@@ -176,7 +176,7 @@ cacert:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.5
+        helm.sh/chart: snyk-broker-0.0.0
       name: snyk-broker-RELEASE-NAME
       namespace: NAMESPACE
 cacertfile:
@@ -188,7 +188,7 @@ cacertfile:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.5
+        helm.sh/chart: snyk-broker-0.0.0
       name: github-com-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -296,7 +296,7 @@ cacertfile:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.5
+        helm.sh/chart: snyk-broker-0.0.0
       name: github-com-broker-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -317,7 +317,7 @@ cacertfile:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.5
+        helm.sh/chart: snyk-broker-0.0.0
       name: RELEASE-NAME-snyk-broker-cacert-configmap-RELEASE-NAME
       namespace: NAMESPACE
   4: |
@@ -336,6 +336,6 @@ cacertfile:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.5
+        helm.sh/chart: snyk-broker-0.0.0
       name: snyk-broker-RELEASE-NAME
       namespace: NAMESPACE

--- a/charts/snyk-broker/tests/__snapshot__/broker_deployment_customaccept_disablesuffixes_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/broker_deployment_customaccept_disablesuffixes_test.yaml.snap
@@ -9,7 +9,7 @@ customaccept values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.6.5
+        helm.sh/chart: snyk-broker-0.0.0
       name: RELEASE-NAME-snyk-broker-accept-configmap
       namespace: NAMESPACE
   2: |
@@ -20,7 +20,7 @@ customaccept values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.6.5
+        helm.sh/chart: snyk-broker-0.0.0
       name: github-com-broker
       namespace: NAMESPACE
     spec:
@@ -122,7 +122,7 @@ customaccept values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.6.5
+        helm.sh/chart: snyk-broker-0.0.0
       name: github-com-broker-service
       namespace: NAMESPACE
     spec:
@@ -149,6 +149,6 @@ customaccept values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.6.5
+        helm.sh/chart: snyk-broker-0.0.0
       name: snyk-broker
       namespace: NAMESPACE

--- a/charts/snyk-broker/tests/__snapshot__/broker_deployment_customaccept_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/broker_deployment_customaccept_test.yaml.snap
@@ -9,7 +9,7 @@ customaccept values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.5
+        helm.sh/chart: snyk-broker-0.0.0
       name: RELEASE-NAME-snyk-broker-accept-configmap-RELEASE-NAME
       namespace: NAMESPACE
   2: |
@@ -20,7 +20,7 @@ customaccept values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.5
+        helm.sh/chart: snyk-broker-0.0.0
       name: github-com-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -122,7 +122,7 @@ customaccept values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.5
+        helm.sh/chart: snyk-broker-0.0.0
       name: github-com-broker-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -149,6 +149,6 @@ customaccept values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.5
+        helm.sh/chart: snyk-broker-0.0.0
       name: snyk-broker-RELEASE-NAME
       namespace: NAMESPACE

--- a/charts/snyk-broker/tests/__snapshot__/broker_deployment_disablesuffixes_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/broker_deployment_disablesuffixes_test.yaml.snap
@@ -7,7 +7,7 @@ HA mode on:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.6.5
+        helm.sh/chart: snyk-broker-0.0.0
       name: github-com-broker
       namespace: NAMESPACE
     spec:
@@ -107,7 +107,7 @@ HA mode on:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.6.5
+        helm.sh/chart: snyk-broker-0.0.0
       name: github-com-broker-service
       namespace: NAMESPACE
     spec:
@@ -134,7 +134,7 @@ HA mode on:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.6.5
+        helm.sh/chart: snyk-broker-0.0.0
       name: snyk-broker
       namespace: NAMESPACE
 HA mode on with 4 replicas:
@@ -146,7 +146,7 @@ HA mode on with 4 replicas:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.6.5
+        helm.sh/chart: snyk-broker-0.0.0
       name: github-com-broker
       namespace: NAMESPACE
     spec:
@@ -246,7 +246,7 @@ HA mode on with 4 replicas:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.6.5
+        helm.sh/chart: snyk-broker-0.0.0
       name: github-com-broker-service
       namespace: NAMESPACE
     spec:
@@ -273,7 +273,7 @@ HA mode on with 4 replicas:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.6.5
+        helm.sh/chart: snyk-broker-0.0.0
       name: snyk-broker
       namespace: NAMESPACE
 default values:
@@ -285,7 +285,7 @@ default values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.6.5
+        helm.sh/chart: snyk-broker-0.0.0
       name: github-com-broker
       namespace: NAMESPACE
     spec:
@@ -383,7 +383,7 @@ default values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.6.5
+        helm.sh/chart: snyk-broker-0.0.0
       name: github-com-broker-service
       namespace: NAMESPACE
     spec:
@@ -410,7 +410,7 @@ default values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.6.5
+        helm.sh/chart: snyk-broker-0.0.0
       name: snyk-broker
       namespace: NAMESPACE
 preflight checks off:
@@ -422,7 +422,7 @@ preflight checks off:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.6.5
+        helm.sh/chart: snyk-broker-0.0.0
       name: github-com-broker
       namespace: NAMESPACE
     spec:
@@ -522,7 +522,7 @@ preflight checks off:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.6.5
+        helm.sh/chart: snyk-broker-0.0.0
       name: github-com-broker-service
       namespace: NAMESPACE
     spec:
@@ -549,6 +549,6 @@ preflight checks off:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.6.5
+        helm.sh/chart: snyk-broker-0.0.0
       name: snyk-broker
       namespace: NAMESPACE

--- a/charts/snyk-broker/tests/__snapshot__/broker_deployment_ingress_disablesuffixes_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/broker_deployment_ingress_disablesuffixes_test.yaml.snap
@@ -7,7 +7,7 @@ ingress:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.6.5
+        helm.sh/chart: snyk-broker-0.0.0
       name: github-com-broker
       namespace: NAMESPACE
     spec:
@@ -105,7 +105,7 @@ ingress:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.6.5
+        helm.sh/chart: snyk-broker-0.0.0
       name: RELEASE-NAME-snyk-broker
       namespace: NAMESPACE
     spec:
@@ -125,7 +125,7 @@ ingress:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.6.5
+        helm.sh/chart: snyk-broker-0.0.0
       name: github-com-broker-service
       namespace: NAMESPACE
     spec:
@@ -152,6 +152,6 @@ ingress:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.6.5
+        helm.sh/chart: snyk-broker-0.0.0
       name: snyk-broker
       namespace: NAMESPACE

--- a/charts/snyk-broker/tests/__snapshot__/broker_deployment_ingress_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/broker_deployment_ingress_test.yaml.snap
@@ -7,7 +7,7 @@ ingress:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.5
+        helm.sh/chart: snyk-broker-0.0.0
       name: github-com-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -105,7 +105,7 @@ ingress:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.5
+        helm.sh/chart: snyk-broker-0.0.0
       name: RELEASE-NAME-snyk-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -125,7 +125,7 @@ ingress:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.5
+        helm.sh/chart: snyk-broker-0.0.0
       name: github-com-broker-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -152,6 +152,6 @@ ingress:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.5
+        helm.sh/chart: snyk-broker-0.0.0
       name: snyk-broker-RELEASE-NAME
       namespace: NAMESPACE

--- a/charts/snyk-broker/tests/__snapshot__/broker_deployment_scm_token_pool_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/broker_deployment_scm_token_pool_test.yaml.snap
@@ -7,7 +7,7 @@ github token pool configured:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.5
+        helm.sh/chart: snyk-broker-0.0.0
       name: github-com-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -110,7 +110,7 @@ github token pool configured:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.5
+        helm.sh/chart: snyk-broker-0.0.0
       name: github-com-broker-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -145,7 +145,7 @@ github token pool configured:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.5
+        helm.sh/chart: snyk-broker-0.0.0
       name: snyk-broker-RELEASE-NAME
       namespace: NAMESPACE
 github token pool configured with enabled useExternalSecretScmTokenPool:
@@ -157,7 +157,7 @@ github token pool configured with enabled useExternalSecretScmTokenPool:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.5
+        helm.sh/chart: snyk-broker-0.0.0
       name: github-com-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -255,7 +255,7 @@ github token pool configured with enabled useExternalSecretScmTokenPool:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.5
+        helm.sh/chart: snyk-broker-0.0.0
       name: github-com-broker-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -282,7 +282,7 @@ github token pool configured with enabled useExternalSecretScmTokenPool:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.5
+        helm.sh/chart: snyk-broker-0.0.0
       name: snyk-broker-RELEASE-NAME
       namespace: NAMESPACE
 gitlab token pool configured:
@@ -294,7 +294,7 @@ gitlab token pool configured:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.5
+        helm.sh/chart: snyk-broker-0.0.0
       name: gitlab-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -399,7 +399,7 @@ gitlab token pool configured:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.5
+        helm.sh/chart: snyk-broker-0.0.0
       name: gitlab-broker-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -434,6 +434,6 @@ gitlab token pool configured:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.5
+        helm.sh/chart: snyk-broker-0.0.0
       name: snyk-broker-RELEASE-NAME
       namespace: NAMESPACE

--- a/charts/snyk-broker/tests/__snapshot__/broker_deployment_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/broker_deployment_test.yaml.snap
@@ -7,7 +7,7 @@ HA mode on:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.5
+        helm.sh/chart: snyk-broker-0.0.0
       name: github-com-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -107,7 +107,7 @@ HA mode on:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.5
+        helm.sh/chart: snyk-broker-0.0.0
       name: github-com-broker-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -134,7 +134,7 @@ HA mode on:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.5
+        helm.sh/chart: snyk-broker-0.0.0
       name: snyk-broker-RELEASE-NAME
       namespace: NAMESPACE
 HA mode on with 4 replicas:
@@ -146,7 +146,7 @@ HA mode on with 4 replicas:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.5
+        helm.sh/chart: snyk-broker-0.0.0
       name: github-com-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -246,7 +246,7 @@ HA mode on with 4 replicas:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.5
+        helm.sh/chart: snyk-broker-0.0.0
       name: github-com-broker-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -273,7 +273,7 @@ HA mode on with 4 replicas:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.5
+        helm.sh/chart: snyk-broker-0.0.0
       name: snyk-broker-RELEASE-NAME
       namespace: NAMESPACE
 HTTPS enabled:
@@ -285,7 +285,7 @@ HTTPS enabled:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.5
+        helm.sh/chart: snyk-broker-0.0.0
       name: github-com-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -393,7 +393,7 @@ HTTPS enabled:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.5
+        helm.sh/chart: snyk-broker-0.0.0
       name: github-com-broker-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -429,7 +429,7 @@ HTTPS enabled:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.5
+        helm.sh/chart: snyk-broker-0.0.0
       name: snyk-broker-RELEASE-NAME
       namespace: NAMESPACE
 default values:
@@ -441,7 +441,7 @@ default values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.5
+        helm.sh/chart: snyk-broker-0.0.0
       name: github-com-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -539,7 +539,7 @@ default values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.5
+        helm.sh/chart: snyk-broker-0.0.0
       name: github-com-broker-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -566,7 +566,7 @@ default values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.5
+        helm.sh/chart: snyk-broker-0.0.0
       name: snyk-broker-RELEASE-NAME
       namespace: NAMESPACE
 preflight checks off:
@@ -578,7 +578,7 @@ preflight checks off:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.5
+        helm.sh/chart: snyk-broker-0.0.0
       name: github-com-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -678,7 +678,7 @@ preflight checks off:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.5
+        helm.sh/chart: snyk-broker-0.0.0
       name: github-com-broker-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -705,6 +705,6 @@ preflight checks off:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.5
+        helm.sh/chart: snyk-broker-0.0.0
       name: snyk-broker-RELEASE-NAME
       namespace: NAMESPACE

--- a/charts/snyk-broker/tests/__snapshot__/cra_deployment_digitalocean_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/cra_deployment_digitalocean_test.yaml.snap
@@ -7,7 +7,7 @@ default values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.5
+        helm.sh/chart: snyk-broker-0.0.0
       name: container-registry-agent-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -157,7 +157,7 @@ default values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.5
+        helm.sh/chart: snyk-broker-0.0.0
       name: cra-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:

--- a/charts/snyk-broker/tests/__snapshot__/cra_deployment_disablesuffixes_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/cra_deployment_disablesuffixes_test.yaml.snap
@@ -7,7 +7,7 @@ default values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.6.5
+        helm.sh/chart: snyk-broker-0.0.0
       name: container-registry-agent-broker
       namespace: NAMESPACE
     spec:
@@ -156,7 +156,7 @@ default values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker
-        helm.sh/chart: snyk-broker-2.6.5
+        helm.sh/chart: snyk-broker-0.0.0
       name: cra-service
       namespace: NAMESPACE
     spec:

--- a/charts/snyk-broker/tests/__snapshot__/cra_deployment_harbor_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/cra_deployment_harbor_test.yaml.snap
@@ -7,7 +7,7 @@ default values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.5
+        helm.sh/chart: snyk-broker-0.0.0
       name: container-registry-agent-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -159,7 +159,7 @@ default values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.5
+        helm.sh/chart: snyk-broker-0.0.0
       name: cra-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:

--- a/charts/snyk-broker/tests/__snapshot__/cra_deployment_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/cra_deployment_test.yaml.snap
@@ -7,7 +7,7 @@ default values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.5
+        helm.sh/chart: snyk-broker-0.0.0
       name: container-registry-agent-broker-RELEASE-NAME
       namespace: NAMESPACE
     spec:
@@ -156,7 +156,7 @@ default values:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: snyk-broker-RELEASE-NAME
-        helm.sh/chart: snyk-broker-2.6.5
+        helm.sh/chart: snyk-broker-0.0.0
       name: cra-service-RELEASE-NAME
       namespace: NAMESPACE
     spec:

--- a/charts/snyk-broker/tests/broker_cra_deployment_disablesuffixes_test.yaml
+++ b/charts/snyk-broker/tests/broker_cra_deployment_disablesuffixes_test.yaml
@@ -1,5 +1,7 @@
 suite: test broker deployment (No suffixes)
-templates: 
+chart:
+  version: 0.0.0
+templates:
   - broker_deployment.yaml
   - broker_service.yaml
   - secrets.yaml

--- a/charts/snyk-broker/tests/broker_cra_deployment_test.yaml
+++ b/charts/snyk-broker/tests/broker_cra_deployment_test.yaml
@@ -1,5 +1,7 @@
 suite: test broker deployment
-templates: 
+chart:
+  version: 0.0.0
+templates:
   - broker_deployment.yaml
   - broker_service.yaml
   - secrets.yaml

--- a/charts/snyk-broker/tests/broker_deployment_apprisk_test.yaml
+++ b/charts/snyk-broker/tests/broker_deployment_apprisk_test.yaml
@@ -1,5 +1,7 @@
 suite: test broker deployment
-templates: 
+chart:
+  version: 0.0.0
+templates:
   - broker_deployment.yaml
   - broker_service.yaml
   - secrets.yaml

--- a/charts/snyk-broker/tests/broker_deployment_artifactory_test.yaml
+++ b/charts/snyk-broker/tests/broker_deployment_artifactory_test.yaml
@@ -1,4 +1,6 @@
 suite: broker deployment (artifactory)
+chart:
+  version: 0.0.0
 templates:
   - broker_deployment.yaml
   - broker_service.yaml

--- a/charts/snyk-broker/tests/broker_deployment_configmap_disablesuffixes_test.yaml
+++ b/charts/snyk-broker/tests/broker_deployment_configmap_disablesuffixes_test.yaml
@@ -1,5 +1,7 @@
 suite: test broker deployment (No suffixes)
-templates: 
+chart:
+  version: 0.0.0
+templates:
   - broker_deployment.yaml
   - broker_service.yaml
   - secrets.yaml
@@ -21,5 +23,3 @@ tests:
       caCertFile: testValueSetBySetFile
     asserts:
       - matchSnapshot: {}
-
-

--- a/charts/snyk-broker/tests/broker_deployment_configmap_test.yaml
+++ b/charts/snyk-broker/tests/broker_deployment_configmap_test.yaml
@@ -1,5 +1,7 @@
 suite: test broker deployment
-templates: 
+chart:
+  version: 0.0.0
+templates:
   - broker_deployment.yaml
   - broker_service.yaml
   - secrets.yaml
@@ -21,5 +23,3 @@ tests:
       caCertFile: testValueSetBySetFile
     asserts:
       - matchSnapshot: {}
-
-

--- a/charts/snyk-broker/tests/broker_deployment_customaccept_disablesuffixes_test.yaml
+++ b/charts/snyk-broker/tests/broker_deployment_customaccept_disablesuffixes_test.yaml
@@ -1,5 +1,7 @@
 suite: test broker deployment (No suffixes)
-templates: 
+chart:
+  version: 0.0.0
+templates:
   - broker_deployment.yaml
   - broker_service.yaml
   - secrets.yaml
@@ -12,4 +14,3 @@ tests:
       - ./fixtures/customaccept_values_disablesuffixes.yaml
     asserts:
       - matchSnapshot: {}
-

--- a/charts/snyk-broker/tests/broker_deployment_customaccept_test.yaml
+++ b/charts/snyk-broker/tests/broker_deployment_customaccept_test.yaml
@@ -1,5 +1,7 @@
 suite: test broker deployment
-templates: 
+chart:
+  version: 0.0.0
+templates:
   - broker_deployment.yaml
   - broker_service.yaml
   - secrets.yaml
@@ -12,4 +14,3 @@ tests:
       - ./fixtures/customaccept_values.yaml
     asserts:
       - matchSnapshot: {}
-

--- a/charts/snyk-broker/tests/broker_deployment_disablesuffixes_test.yaml
+++ b/charts/snyk-broker/tests/broker_deployment_disablesuffixes_test.yaml
@@ -1,5 +1,7 @@
 suite: test broker deployment (No suffixes)
-templates: 
+chart:
+  version: 0.0.0
+templates:
   - broker_deployment.yaml
   - broker_service.yaml
   - secrets.yaml

--- a/charts/snyk-broker/tests/broker_deployment_ingress_disablesuffixes_test.yaml
+++ b/charts/snyk-broker/tests/broker_deployment_ingress_disablesuffixes_test.yaml
@@ -1,5 +1,7 @@
 suite: test broker deployment with ingress (No suffixes)
-templates: 
+chart:
+  version: 0.0.0
+templates:
   - broker_deployment.yaml
   - broker_service.yaml
   - secrets.yaml
@@ -12,5 +14,3 @@ tests:
       - ./fixtures/default_values_with_ingress_disablesuffixes.yaml
     asserts:
       - matchSnapshot: {}
-
-

--- a/charts/snyk-broker/tests/broker_deployment_ingress_test.yaml
+++ b/charts/snyk-broker/tests/broker_deployment_ingress_test.yaml
@@ -1,5 +1,7 @@
 suite: test broker deployment with ingress
-templates: 
+chart:
+  version: 0.0.0
+templates:
   - broker_deployment.yaml
   - broker_service.yaml
   - secrets.yaml
@@ -12,5 +14,3 @@ tests:
       - ./fixtures/default_values_with_ingress.yaml
     asserts:
       - matchSnapshot: {}
-
-

--- a/charts/snyk-broker/tests/broker_deployment_nexus_test.yaml
+++ b/charts/snyk-broker/tests/broker_deployment_nexus_test.yaml
@@ -1,11 +1,11 @@
 suite: broker deployment (nexus)
+chart:
+  version: 0.0.0
 values:
   - ./fixtures/default_values.yaml
 
 tests:
   - it: should create secret if brokerClientValidationUrl, baseNexusUrl and nexusUrl are defined
-    chart:
-      version: 0.0.0
     template: secrets.yaml
 
     set:
@@ -26,8 +26,6 @@ tests:
           value: https://username:password@your-domain.com/service/rest/v1/status/check
 
   - it: should create secret if brokerClientValidationUrl and nexusUrl are defined
-    chart:
-      version: 0.0.0
     template: secrets.yaml
 
     set:
@@ -47,8 +45,6 @@ tests:
           value: https://username:password@your-domain.com/service/rest/v1/status/check
 
   - it: should create secret if brokerClientValidationUrl and baseNexusUrl are defined
-    chart:
-      version: 0.0.0
     template: secrets.yaml
 
     set:
@@ -68,8 +64,6 @@ tests:
           value: https://username:password@your-domain.com/service/rest/v1/status/check
 
   - it: should not create secret for brokerClientValidationUrl if value is empty
-    chart:
-      version: 0.0.0
     template: secrets.yaml
 
     set:
@@ -84,8 +78,6 @@ tests:
           value: nexus-broker-client-validation-url
 
   - it: should render render nexusUrl, baseNexusUrl and brokerClientValidationUrl as secrets
-    chart:
-      version: 0.0.0
     templates:
       - broker_deployment.yaml
       - broker_service.yaml

--- a/charts/snyk-broker/tests/broker_deployment_scm_token_pool_test.yaml
+++ b/charts/snyk-broker/tests/broker_deployment_scm_token_pool_test.yaml
@@ -1,4 +1,6 @@
 suite: test broker deployment (credential pooling)
+chart:
+  version: 0.0.0
 templates:
   - broker_deployment.yaml
   - broker_service.yaml

--- a/charts/snyk-broker/tests/broker_deployment_test.yaml
+++ b/charts/snyk-broker/tests/broker_deployment_test.yaml
@@ -1,5 +1,7 @@
 suite: test broker deployment
-templates: 
+chart:
+  version: 0.0.0
+templates:
   - broker_deployment.yaml
   - broker_service.yaml
   - secrets.yaml

--- a/charts/snyk-broker/tests/cra_deployment_digitalocean_test.yaml
+++ b/charts/snyk-broker/tests/cra_deployment_digitalocean_test.yaml
@@ -1,5 +1,7 @@
 suite: test broker deployment
-templates: 
+chart:
+  version: 0.0.0
+templates:
   - cra_deployment.yaml
   - broker_deployment.yaml
 

--- a/charts/snyk-broker/tests/cra_deployment_disablesuffixes_test.yaml
+++ b/charts/snyk-broker/tests/cra_deployment_disablesuffixes_test.yaml
@@ -1,5 +1,7 @@
 suite: test broker deployment (No suffixes)
-templates: 
+chart:
+  version: 0.0.0
+templates:
   - cra_deployment.yaml
   - broker_deployment.yaml
 

--- a/charts/snyk-broker/tests/cra_deployment_harbor_test.yaml
+++ b/charts/snyk-broker/tests/cra_deployment_harbor_test.yaml
@@ -1,5 +1,7 @@
 suite: test broker deployment
-templates: 
+chart:
+  version: 0.0.0
+templates:
   - cra_deployment.yaml
   - broker_deployment.yaml
 

--- a/charts/snyk-broker/tests/cra_deployment_test.yaml
+++ b/charts/snyk-broker/tests/cra_deployment_test.yaml
@@ -1,5 +1,7 @@
 suite: test broker deployment
-templates: 
+chart:
+  version: 0.0.0
+templates:
   - cra_deployment.yaml
   - broker_deployment.yaml
 


### PR DESCRIPTION
Small quality of life test improvement. We specify `chart.version` in unit tests, so snapshots do not have to be updated when we release a new version.

How the unit tests will/should look like:
```yaml
suite: test bla-bla-bla
chart:
  version: 0.0.0  # <- this renders a fixed version in snapshots.
templates:
...
```