### PR TITLE
fix: extra pod specs for cra

### DIFF
--- a/charts/snyk-broker/Chart.yaml
+++ b/charts/snyk-broker/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: snyk-broker
-version: 2.6.5
+version: 2.6.6
 description: A Helm chart for Kubernetes
 type: application

--- a/charts/snyk-broker/templates/cra_deployment.yaml
+++ b/charts/snyk-broker/templates/cra_deployment.yaml
@@ -25,6 +25,9 @@ spec:
         app.kubernetes.io/name: {{ .Release.Name }}-cr{{if not .Values.disableSuffixes }}-{{ .Release.Name }}{{ end }}
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
+      {{- if .Values.extraPodSpecsCr }}
+          {{- toYaml .Values.extraPodSpecsCr | nindent 6 }}
+      {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
@@ -42,7 +45,7 @@ spec:
               cpu: {{ .Values.crResources.requests.cpu }}
               memory: {{ .Values.crResources.requests.memory}}
           securityContext:
-            {{- toYaml .Values.securityContextCr | nindent 12 }}      
+            {{- toYaml .Values.securityContextCr | nindent 12 }}
           image: "{{ .Values.image.crRepository }}:{{ .Values.crImage}}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
@@ -50,14 +53,14 @@ spec:
               containerPort: {{ .Values.deployment.container.crSnykPort }}
           env:
             - name: SNYK_PORT
-              value: {{ .Values.deployment.container.crSnykPort | squote }} 
+              value: {{ .Values.deployment.container.crSnykPort | squote }}
          {{- if .Values.tlsRejectUnauthorized  }}
          # Troubleshooting - Set to 0 for SSL inspection testing
             - name: NODE_TLS_REJECT_UNAUTHORIZED
               value: "0"
          {{- end }}
          {{- if .Values.caCert }}
-         # HTTPS Inspection 
+         # HTTPS Inspection
             - name: CA_CERT
               value: /home/node/cacert/{{ .Values.caCert }}
             - name: NODE_EXTRA_CA_CERTS
@@ -66,7 +69,7 @@ spec:
          {{- range .Values.env }}
          # custom env var in override.yaml
             - name: {{ .name }}
-              value: {{ .value | squote }} 
+              value: {{ .value | squote }}
         {{- end}}
         {{- if .Values.caCert }}
           volumeMounts:

--- a/charts/snyk-broker/tests/__snapshot__/broker_cra_deployment_extraPodSpecs_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/broker_cra_deployment_extraPodSpecs_test.yaml.snap
@@ -1,0 +1,122 @@
+renders extraPodSpecs CRA:
+  1: |
+    containers:
+      - env:
+          - name: BROKER_SERVER_URL
+            value: https://broker.test.snyk.io
+          - name: BROKER_HEALTHCHECK_PATH
+            value: /healthcheck
+          - name: BROKER_SYSTEMCHECK_PATH
+            value: /systemcheck
+          - name: BROKER_TOKEN
+            valueFrom:
+              secretKeyRef:
+                key: container-registry-agent-broker-token-key
+                name: container-registry-agent-broker-token-RELEASE-NAME
+          - name: CR_AGENT_URL
+            value: http://cra-service-RELEASE-NAME:8081
+          - name: CR_TYPE
+            value: ecr
+          - name: CR_ROLE_ARN
+            value: arn:aws-us-gov:iam::123456789012:role
+          - name: CR_REGION
+            value: eu-west
+          - name: CR_EXTERNAL_ID
+            value: 11111111-1111-1111-1111-111111111111
+          - name: PORT
+            value: "8000"
+          - name: BROKER_CLIENT_URL
+            value: http://container-registry-agent-broker-service-RELEASE-NAME:8000
+          - name: BROKER_CLIENT_VALIDATION_URL
+            value: http://cra-service-RELEASE-NAME:8081/healthcheck
+          - name: LOG_LEVEL
+            value: info
+          - name: LOG_ENABLE_BODY
+            value: "false"
+          - name: BROKER_DISPATCHER_BASE_URL
+            value: https://api.test.snyk.io
+        image: snyk/broker:container-registry-agent
+        imagePullPolicy: Always
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthcheck
+            port: 8000
+            scheme: HTTP
+          initialDelaySeconds: 3
+          periodSeconds: 10
+          timeoutSeconds: 1
+        name: container-registry-agent-broker-RELEASE-NAME
+        ports:
+          - containerPort: 8000
+            name: http
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthcheck
+            port: 8000
+            scheme: HTTP
+          initialDelaySeconds: 3
+          periodSeconds: 10
+          timeoutSeconds: 1
+        resources:
+          limits:
+            cpu: 1
+            memory: 256Mi
+          requests:
+            cpu: 1
+            memory: 256Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 1000
+        volumeMounts: null
+    nodeSelector:
+      corp.io/node-classification: snyk
+    securityContext: {}
+    serviceAccountName: snyk-broker-RELEASE-NAME
+    tolerations:
+      - effect: NoSchedule
+        key: networking/something
+        operator: Equal
+        value: internal-pods
+    volumes: null
+  2: |
+    containers:
+      - env:
+          - name: SNYK_PORT
+            value: "8081"
+        image: snyk/container-registry-agent:latest
+        imagePullPolicy: Always
+        name: container-registry-agent-RELEASE-NAME
+        ports:
+          - containerPort: 8081
+            name: http
+        resources:
+          limits:
+            cpu: 1
+            memory: 2Gi
+          requests:
+            cpu: 1
+            memory: 2Gi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
+          readOnlyRootFilesystem: false
+          runAsNonRoot: true
+          runAsUser: 1000
+    nodeSelector:
+      corp.io/node-classification: snyk
+    securityContext: {}
+    serviceAccountName: snyk-broker-RELEASE-NAME
+    tolerations:
+      - effect: NoSchedule
+        key: networking/something
+        operator: Equal
+        value: internal-pods

--- a/charts/snyk-broker/tests/broker_cra_deployment_extraPodSpecs_test.yaml
+++ b/charts/snyk-broker/tests/broker_cra_deployment_extraPodSpecs_test.yaml
@@ -1,0 +1,20 @@
+suite: test broker deployment with extraPodSpec
+chart:
+  version: 0.0.0
+templates:
+  - broker_deployment.yaml
+  - cra_deployment.yaml
+values:
+  - ./fixtures/default_values_cra.yaml
+  - ./fixtures/extra_pod_spec_values.yaml
+
+tests:
+  - it: renders extraPodSpecs CRA
+    asserts:
+      - matchSnapshot:
+          path: spec.template.spec
+        template: broker_deployment.yaml
+      - matchSnapshot:
+          path: spec.template.spec
+        template: cra_deployment.yaml
+        documentIndex: 0

--- a/charts/snyk-broker/tests/fixtures/extra_pod_spec_values.yaml
+++ b/charts/snyk-broker/tests/fixtures/extra_pod_spec_values.yaml
@@ -1,0 +1,18 @@
+
+extraPodSpecs:
+  tolerations:
+  - key: "networking/something"
+    operator: "Equal"
+    value: "internal-pods"
+    effect: "NoSchedule"
+  nodeSelector:
+    corp.io/node-classification: snyk
+
+extraPodSpecsCr:
+  tolerations:
+  - key: "networking/something"
+    operator: "Equal"
+    value: "internal-pods"
+    effect: "NoSchedule"
+  nodeSelector:
+    corp.io/node-classification: snyk

--- a/charts/snyk-broker/values.yaml
+++ b/charts/snyk-broker/values.yaml
@@ -26,7 +26,7 @@ replicaCount: 2
 
 ##### SCM Generic #####
 
-# scmType is used to define the Source Control that you are connecting to. 
+# scmType is used to define the Source Control that you are connecting to.
 
 # Allowed values for scmType:
 #   GitHub.com: github-com
@@ -76,7 +76,7 @@ bitbucketPassword: ""
 bitbucket: ""
 
 # Bitbucket API URL - do not prepend HTTPS
-bitbucketApi: "" 
+bitbucketApi: ""
 
 
 ##### GitLab #####
@@ -165,16 +165,16 @@ crImage: "latest"
 # Set to 'true' to enable Code Agent
 enableCodeAgent: ""
 
-# Only adjust this value if advised to by Snyk Representative. Used to upload content to non-standard environment. 
+# Only adjust this value if advised to by Snyk Representative. Used to upload content to non-standard environment.
 upstreamUrlCodeAgent: ""
 
-# Snyk API token. Allows Code Agent to upload source code. Group > Settings > Service Accounts 
+# Snyk API token. Allows Code Agent to upload source code. Group > Settings > Service Accounts
 snykToken: ""
 
 #CA Image Tag. Do not touch unless instructed by Snyk Representative
 caImage: "latest"
 
-# Only adjust this value if advised to by Snyk Representative. This is the URL of the Snyk Code Agent. This helm chart already connects everything. 
+# Only adjust this value if advised to by Snyk Representative. This is the URL of the Snyk Code Agent. This helm chart already connects everything.
 gitClientUrl: ""
 
 ##### Snyk Code Local Engine #####
@@ -203,17 +203,17 @@ httpsKey: ""
 
 ##### HTTPS Inspection #####
 
-# Not supported by Snyk Container Registry Agent or Snyk Code Agent (use tlsRejectUnauthorized instead). Location of mounted custom certificate. To allow visibility for SSL Inspection. 
+# Not supported by Snyk Container Registry Agent or Snyk Code Agent (use tlsRejectUnauthorized instead). Location of mounted custom certificate. To allow visibility for SSL Inspection.
 caCert: ""
 
 caCertFile: ""
 
-# Set to "0" to disable trust validation when using self signed certificates. 
-tlsRejectUnauthorized: "" 
+# Set to "0" to disable trust validation when using self signed certificates.
+tlsRejectUnauthorized: ""
 
 ##### Use behind proxy #####
 
-# Do not change unless advised by your Snyk Representative. You probably need to use HTTPS proxy setting and leave this blank. - HTTP Proxy URL 
+# Do not change unless advised by your Snyk Representative. You probably need to use HTTPS proxy setting and leave this blank. - HTTP Proxy URL
 httpProxy: ""
 
 # HTTPS Proxy URL - This will apply to both Snyk Broker and Snyk Code Agent
@@ -251,7 +251,7 @@ brokerLivenessProbe:
     initialDelaySeconds: 3
     periodSeconds: 10
     timeoutSeconds: 1
-    failureThreshold: 3  
+    failureThreshold: 3
 
 
 brokerReadinessProbe:
@@ -297,7 +297,7 @@ caResources:
 
 ##### Ports for Broker, Code Agent, Container Registry Agent #####
 deployment:
-   container: 
+   container:
      containerPort: 8000
      crSnykPort: 8081
      caSnykPort: 3000
@@ -319,12 +319,12 @@ serviceAccount:
 podAnnotations: {}
 
 podSecurityContext: {}
- 
+
 
 ##### Security Context #####
-# These can be adjusted at your own risk. 
+# These can be adjusted at your own risk.
 
-securityContext: 
+securityContext:
    capabilities:
      drop:
      - ALL
@@ -333,7 +333,7 @@ securityContext:
    runAsNonRoot: true
    runAsUser: 1000
 
-securityContextCr: 
+securityContextCr:
    capabilities:
      drop:
      - ALL
@@ -342,7 +342,7 @@ securityContextCr:
    runAsNonRoot: true
    runAsUser: 1000
 
-securityContextCa: 
+securityContextCa:
    capabilities:
      drop:
      - ALL
@@ -354,11 +354,11 @@ securityContextCa:
 ##### Service Types #####
 # If you prefer to adjust how communication to the cluster occurs, these values can be adjusted
 service:
- 
+
   # Snyk Broker
   brokerType: ClusterIP
- 
-  # Container Registry Agent 
+
+  # Container Registry Agent
   crType: ClusterIP
 
   # Code Agent
@@ -416,7 +416,7 @@ extraVolumes: []
 extraVolumeMounts: []
 extraContainerSpecs:
 
-extraPodSpecs: 
+extraPodSpecs:
   # tolerations:
   # - key: "networking/something"
   #   operator: "Equal"
@@ -424,6 +424,9 @@ extraPodSpecs:
   #   effect: "NoSchedule"
   # nodeSelector:
   #   networking.company.com/network-segment: internal-pods
+
+extraPodSpecsCr:
+  # As above, for Container Registry Agent
 
 ##### The Broker is designed to work with multiple replicas (min 2, max 4) only with High Availability mode enabled.
 


### PR DESCRIPTION
Allows `extraPodSpecs` to be specified for Container Registry Agent
