### PR TITLE
fix: toggle service account

### DIFF
--- a/charts/snyk-broker/Chart.yaml
+++ b/charts/snyk-broker/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: snyk-broker
-version: 2.7.1
+version: 2.7.2
 description: A Helm chart for Kubernetes
 type: application

--- a/charts/snyk-broker/templates/_helpers.tpl
+++ b/charts/snyk-broker/templates/_helpers.tpl
@@ -59,7 +59,12 @@ Create the name of the service account to use
 */}}
 {{- define "snyk-broker.serviceAccountName" -}}
 {{- if .Values.serviceAccount.create }}
-{{- default (include "snyk-broker.fullname" .) .Values.serviceAccount.name }}
+{{- $saName := default (include "snyk-broker.fullname" .) .Values.serviceAccount.name -}}
+{{- if .Values.disableSuffixes }}
+{{- printf "%s" $saName }}
+{{- else }}
+{{- printf "%s-%s" $saName .Release.Name }}
+{{- end }}
 {{- else }}
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}

--- a/charts/snyk-broker/templates/broker_deployment.yaml
+++ b/charts/snyk-broker/templates/broker_deployment.yaml
@@ -30,7 +30,9 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      serviceAccountName: {{ include "snyk-broker.serviceAccountName" . }}{{if not .Values.disableSuffixes }}-{{ .Release.Name }}{{ end }}
+      {{- if .Values.serviceAccount.enabled }}
+      serviceAccountName: {{ include "snyk-broker.serviceAccountName" . }}
+      {{- end }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/charts/snyk-broker/templates/code_agent_deployment.yaml
+++ b/charts/snyk-broker/templates/code_agent_deployment.yaml
@@ -8,9 +8,7 @@ metadata:
     app.kubernetes.io/name: {{ .Release.Name }}-ca
     app.kubernetes.io/instance: {{ .Release.Name }}
 spec:
-  {{- if not .Values.autoscaling.enabled }}
   replicas: 1
-  {{- end }}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ .Release.Name }}-ca
@@ -29,7 +27,9 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      serviceAccountName: {{ include "snyk-broker.serviceAccountName" . }}{{if not .Values.disableSuffixes }}-{{ .Release.Name }}{{ end }}
+      {{- if .Values.serviceAccount.enabled }}
+      serviceAccountName: {{ include "snyk-broker.serviceAccountName" . }}
+      {{- end }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
@@ -78,10 +78,10 @@ spec:
          {{- range .Values.env }}
          # custom env var in override.yaml
             - name: {{ .name }}
-              value: {{ .value | squote }} 
+              value: {{ .value | squote }}
         {{- end}}
-        
----                     
+
+---
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/snyk-broker/templates/cra_deployment.yaml
+++ b/charts/snyk-broker/templates/cra_deployment.yaml
@@ -30,7 +30,9 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      serviceAccountName: {{ include "snyk-broker.serviceAccountName" . }}{{if not .Values.disableSuffixes }}-{{ .Release.Name }}{{ end }}
+      {{- if .Values.serviceAccount.enabled }}
+      serviceAccountName: {{ include "snyk-broker.serviceAccountName" . }}
+      {{- end }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/charts/snyk-broker/templates/serviceaccount.yaml
+++ b/charts/snyk-broker/templates/serviceaccount.yaml
@@ -1,8 +1,8 @@
-{{- if .Values.serviceAccount.create -}}
+{{- if ( and .Values.serviceAccount.create .Values.serviceAccount.enabled ) -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "snyk-broker.serviceAccountName" . }}{{if not .Values.disableSuffixes }}-{{ .Release.Name }}{{ end }}
+  name: {{ include "snyk-broker.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "snyk-broker.labels" . }}

--- a/charts/snyk-broker/tests/broker_deployment_service_account_test.yaml
+++ b/charts/snyk-broker/tests/broker_deployment_service_account_test.yaml
@@ -1,0 +1,121 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+suite: test broker service account
+chart:
+  version: 0.0.0
+templates:
+  - &brokerDep broker_deployment.yaml
+  - &craDep cra_deployment.yaml
+  - &caDep code_agent_deployment.yaml
+  - &sa serviceaccount.yaml
+values:
+  - ../values.yaml
+  - ./fixtures/default_values.yaml
+set:
+  enableCodeAgent: true
+  scmType: container-registry-agent
+
+tests:
+  - it: uses the generated service account
+    asserts:
+    - equal:
+        path: &serviceAccountNamePath spec.template.spec.serviceAccountName
+        value: &defaultServiceAccountName snyk-broker-RELEASE-NAME
+      template: *brokerDep
+    - equal:
+        path: *serviceAccountNamePath
+        value: *defaultServiceAccountName
+      template: *craDep
+      documentIndex: 0
+    - equal:
+        path: *serviceAccountNamePath
+        value: *defaultServiceAccountName
+      template: *caDep
+      documentIndex: 0
+    - equal:
+        path: metadata.name
+        value: *defaultServiceAccountName
+      template: *sa
+  - it: creates a serviceaccount with specified name
+    set:
+      serviceAccount.name: "my-custom-service-account-name"
+    asserts:
+    - equal:
+        path: *serviceAccountNamePath
+        value: &myCustomServiceAccountName my-custom-service-account-name-RELEASE-NAME
+      template: *brokerDep
+    - equal:
+        path: *serviceAccountNamePath
+        value: *myCustomServiceAccountName
+      template: *craDep
+      documentIndex: 0
+    - equal:
+        path: *serviceAccountNamePath
+        value: *myCustomServiceAccountName
+      template: *caDep
+      documentIndex: 0
+    - equal:
+        path: metadata.name
+        value: *myCustomServiceAccountName
+      template: *sa
+  - it: falls back to the `default` service account if name is empty
+    set:
+      serviceAccount.create: false
+      serviceAccount.name: ""
+    asserts:
+    - hasDocuments:
+        count: 0
+      template: *sa
+    - equal:
+        path: *serviceAccountNamePath
+        value: &defaultServiceAccount default
+      template: *brokerDep
+    - equal:
+        path: *serviceAccountNamePath
+        value: *defaultServiceAccount
+      template: *craDep
+      documentIndex: 0
+    - equal:
+        path: *serviceAccountNamePath
+        value: *defaultServiceAccount
+      template: *caDep
+      documentIndex: 0
+  - it: uses an external service account
+    set:
+      serviceAccount.create: false
+      serviceAccount.name: "my-external-service-account"
+    asserts:
+    - hasDocuments:
+        count: 0
+      template: *sa
+    - equal:
+        path: *serviceAccountNamePath
+        value: &myExternalServiceAccount my-external-service-account
+      template: *brokerDep
+    - equal:
+        path: *serviceAccountNamePath
+        value: *myExternalServiceAccount
+      template: *craDep
+      documentIndex: 0
+    - equal:
+        path: *serviceAccountNamePath
+        value: *myExternalServiceAccount
+      template: *caDep
+      documentIndex: 0
+  - it: does not use or generate a service account
+    set:
+      serviceAccount.enabled: false
+    asserts:
+    - hasDocuments:
+        count: 0
+      template: *sa
+    - notExists:
+        path: *serviceAccountNamePath
+      template: *brokerDep
+    - notExists:
+        path: *serviceAccountNamePath
+      template: *craDep
+      documentIndex: 0
+    - notExists:
+        path: *serviceAccountNamePath
+      template: *caDep
+      documentIndex: 0

--- a/charts/snyk-broker/values.schema.json
+++ b/charts/snyk-broker/values.schema.json
@@ -371,6 +371,9 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
         "create": {
           "type": "boolean"
         },

--- a/charts/snyk-broker/values.yaml
+++ b/charts/snyk-broker/values.yaml
@@ -335,24 +335,24 @@ nameOverride: ""
 fullnameOverride: ""
 
 
-##### Service Account Values. Nothing to change here #####
+##### Service Account #####
 
 serviceAccount:
+  # Specifies whether a service account should be used
+  enabled: true
   # Specifies whether a service account should be created
   create: true
   # Annotations to add to the service account
   annotations: {}
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
+  # If create==false, ensure this serviceAccount exists
   name: "snyk-broker"
-
-podAnnotations: {}
-
-podSecurityContext: {}
-
 
 ##### Security Context #####
 # These can be adjusted at your own risk.
+
+podSecurityContext: {}
 
 securityContext:
    capabilities:
@@ -457,3 +457,5 @@ extraPodSpecs:
 
 extraPodSpecsCr:
   # As above, for Container Registry Agent
+
+podAnnotations: {}


### PR DESCRIPTION
### What

- Allows `serviceAccount` creation to be disabled
- Allows external `serviceAccount` to be specified
- Removes deprecated autoscaling values

### Why

- Allow deployment to environments without service accounts
