### PR TITLE
fix: correctly set tlsRejectUnauthorized

### DIFF
--- a/charts/snyk-broker/Chart.yaml
+++ b/charts/snyk-broker/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: snyk-broker
-version: 2.7.2
+version: 2.7.3
 description: A Helm chart for Kubernetes
 type: application

--- a/charts/snyk-broker/templates/_helpers.tpl
+++ b/charts/snyk-broker/templates/_helpers.tpl
@@ -135,3 +135,19 @@ include "snyk-broker.genericSecretName" (dict "Context" $ "secretName" "secret-n
 {{- define "snyk-broker.caCertSecretName" -}}
 {{- include "snyk-broker.genericSecretName" (dict "Context" . "secretName" "cacert-secret" ) -}}
 {{- end }}
+
+{{/*
+Handle tlsRejectUnauthorized.
+If this is set to `false` (bool) we _want_ to disable trust. We don't allow `true`.
+If this is set to "" we want to enable trust - any other allowed string value disables.
+Checking for definition is insufficient
+*/}}
+{{- define "snyk-broker.setTlsRejectUnauthorized" -}}
+{{- $tlsRejectUnauthorized := .Values.tlsRejectUnauthorized -}}
+{{- if eq (kindOf $tlsRejectUnauthorized ) "bool" -}}
+true
+{{- end }}
+{{- if ( and ( eq (kindOf $tlsRejectUnauthorized ) "string") ( not ( eq $tlsRejectUnauthorized "" ) ) ) -}}
+true
+{{- end }}
+{{- end }}

--- a/charts/snyk-broker/templates/_helpers.tpl
+++ b/charts/snyk-broker/templates/_helpers.tpl
@@ -140,6 +140,7 @@ include "snyk-broker.genericSecretName" (dict "Context" $ "secretName" "secret-n
 Handle tlsRejectUnauthorized.
 If this is set to `false` (bool) we _want_ to disable trust. We don't allow `true`.
 If this is set to "" we want to enable trust - any other allowed string value disables.
+If this is set to `"0"` Helm might cast it as an integer - we need to catch that.
 Checking for definition is insufficient
 */}}
 {{- define "snyk-broker.setTlsRejectUnauthorized" -}}
@@ -148,6 +149,9 @@ Checking for definition is insufficient
 true
 {{- end }}
 {{- if ( and ( eq (kindOf $tlsRejectUnauthorized ) "string") ( not ( eq $tlsRejectUnauthorized "" ) ) ) -}}
+true
+{{- end }}
+{{- if eq (toString $tlsRejectUnauthorized) "0" -}}
 true
 {{- end }}
 {{- end }}

--- a/charts/snyk-broker/templates/broker_deployment.yaml
+++ b/charts/snyk-broker/templates/broker_deployment.yaml
@@ -1,3 +1,4 @@
+{{ $setTlsRejectUnauthorized := include "snyk-broker.setTlsRejectUnauthorized" . }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -428,7 +429,7 @@ spec:
             - name: HTTPS_KEY
               value: /home/node/tls-cert/tls.key
          {{- end }}
-         {{- if or ( and .Values.tlsRejectUnauthorized (not .Values.caCert ) (not .Values.caCertFile) ) ( and (or .Values.caCert .Values.caCertFile ) .Values.disableCaCertTrust ) }}
+         {{- if or ( and $setTlsRejectUnauthorized (not .Values.caCert ) (not .Values.caCertFile) ) ( and (or .Values.caCert .Values.caCertFile ) .Values.disableCaCertTrust ) }}
          # Troubleshooting - Set to 0 for SSL inspection testing
             - name: NODE_TLS_REJECT_UNAUTHORIZED
               value: "0"

--- a/charts/snyk-broker/templates/code_agent_deployment.yaml
+++ b/charts/snyk-broker/templates/code_agent_deployment.yaml
@@ -1,3 +1,4 @@
+{{ $setTlsRejectUnauthorized := include "snyk-broker.setTlsRejectUnauthorized" . }}
 {{- if .Values.enableCodeAgent }}
 apiVersion: apps/v1
 kind: Deployment
@@ -60,7 +61,7 @@ spec:
                 secretKeyRef:
                   name: snyk-token{{if not .Values.disableSuffixes }}-{{ .Release.Name }}{{ end }}
                   key: snyk-token-key
-         {{- if .Values.tlsRejectUnauthorized  }}
+         {{- if $setTlsRejectUnauthorized }}
          # Troubleshooting - Set to 0 for SSL inspection testing
             - name: NODE_TLS_REJECT_UNAUTHORIZED
               value: "0"
@@ -78,10 +79,9 @@ spec:
          {{- range .Values.env }}
          # custom env var in override.yaml
             - name: {{ .name }}
-              value: {{ .value | squote }} 
+              value: {{ .value | squote }}
         {{- end}}
-        
----                     
+---
 apiVersion: v1
 kind: Service
 metadata:
@@ -97,5 +97,4 @@ spec:
   selector:
     app.kubernetes.io/name: {{ .Release.Name }}-ca
     app.kubernetes.io/instance: {{ .Release.Name }}
-
 {{- end }}

--- a/charts/snyk-broker/templates/code_agent_deployment.yaml
+++ b/charts/snyk-broker/templates/code_agent_deployment.yaml
@@ -9,9 +9,7 @@ metadata:
     app.kubernetes.io/name: {{ .Release.Name }}-ca
     app.kubernetes.io/instance: {{ .Release.Name }}
 spec:
-  {{- if not .Values.autoscaling.enabled }}
   replicas: 1
-  {{- end }}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ .Release.Name }}-ca

--- a/charts/snyk-broker/templates/cra_deployment.yaml
+++ b/charts/snyk-broker/templates/cra_deployment.yaml
@@ -1,3 +1,4 @@
+{{ $setTlsRejectUnauthorized := include "snyk-broker.setTlsRejectUnauthorized" . }}
 {{- if eq .Values.scmType "container-registry-agent" }}
 apiVersion: apps/v1
 kind: Deployment
@@ -52,7 +53,7 @@ spec:
           env:
             - name: SNYK_PORT
               value: {{ .Values.deployment.container.crSnykPort | squote }}
-         {{- if .Values.tlsRejectUnauthorized  }}
+         {{- if $setTlsRejectUnauthorized }}
          # Troubleshooting - Set to 0 for SSL inspection testing
             - name: NODE_TLS_REJECT_UNAUTHORIZED
               value: "0"

--- a/charts/snyk-broker/tests/broker_cra_deployment_disable_tls_test.yaml
+++ b/charts/snyk-broker/tests/broker_cra_deployment_disable_tls_test.yaml
@@ -61,6 +61,18 @@ tests:
         documentSelector:
           path: kind
           value: Deployment
+  - it: disables tls trust with '0' (integer)
+    set:
+      tlsRejectUnauthorized: 0
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: NODE_TLS_REJECT_UNAUTHORIZED
+            value: "0"
+        documentSelector:
+          path: kind
+          value: Deployment
   - it: enables tls trust by default "" (string)
     set:
       tlsRejectUnauthorized: ""
@@ -78,4 +90,4 @@ tests:
       tlsRejectUnauthorized: true
     asserts:
       - failedTemplate:
-          errorMessage: "values don't meet the specifications of the schema(s) in the following chart(s):\nsnyk-broker:\n- tlsRejectUnauthorized: tlsRejectUnauthorized must be one of the following: \"\", \"0\", \"false\", false, \"disable\"\n"
+          errorMessage: "values don't meet the specifications of the schema(s) in the following chart(s):\nsnyk-broker:\n- tlsRejectUnauthorized: tlsRejectUnauthorized must be one of the following: \"\", 0, \"0\", \"false\", false, \"disable\"\n"

--- a/charts/snyk-broker/tests/broker_cra_deployment_disable_tls_test.yaml
+++ b/charts/snyk-broker/tests/broker_cra_deployment_disable_tls_test.yaml
@@ -1,0 +1,78 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+suite: test broker deployment with CA
+chart:
+  version: 0.0.0
+templates:
+  - broker_deployment.yaml
+  - cra_deployment.yaml
+values:
+  - ./fixtures/default_values.yaml
+  - ./fixtures/default_values_cra.yaml
+
+tests:
+  - it: disables tls trust with "disable" (string)
+    set:
+      tlsRejectUnauthorized: "disable"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: NODE_TLS_REJECT_UNAUTHORIZED
+            value: "0"
+        documentSelector:
+          path: kind
+          value: Deployment
+  - it: disables tls trust with "0" (string)
+    set:
+      tlsRejectUnauthorized: "0"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: NODE_TLS_REJECT_UNAUTHORIZED
+            value: "0"
+        documentSelector:
+          path: kind
+          value: Deployment
+  - it: disables tls trust with "false" (string)
+    set:
+      tlsRejectUnauthorized: "false"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: NODE_TLS_REJECT_UNAUTHORIZED
+            value: "0"
+        documentSelector:
+          path: kind
+          value: Deployment
+  - it: disables tls trust with false (boolean)
+    set:
+      tlsRejectUnauthorized: false
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: NODE_TLS_REJECT_UNAUTHORIZED
+            value: "0"
+        documentSelector:
+          path: kind
+          value: Deployment
+  - it: enables tls trust by default "" (string)
+    set:
+      tlsRejectUnauthorized: ""
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: NODE_TLS_REJECT_UNAUTHORIZED
+            value: "0"
+        documentSelector:
+          path: kind
+          value: Deployment
+  - it: does not allow true (bool)
+    set:
+      tlsRejectUnauthorized: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "values don't meet the specifications of the schema(s) in the following chart(s):\nsnyk-broker:\n- tlsRejectUnauthorized: tlsRejectUnauthorized must be one of the following: \"\", \"0\", \"false\", false, \"disable\"\n"

--- a/charts/snyk-broker/tests/broker_cra_deployment_disable_tls_test.yaml
+++ b/charts/snyk-broker/tests/broker_cra_deployment_disable_tls_test.yaml
@@ -5,9 +5,12 @@ chart:
 templates:
   - broker_deployment.yaml
   - cra_deployment.yaml
+  - code_agent_deployment.yaml
 values:
   - ./fixtures/default_values.yaml
   - ./fixtures/default_values_cra.yaml
+set:
+  enableCodeAgent: true
 
 tests:
   - it: disables tls trust with "disable" (string)

--- a/charts/snyk-broker/values.schema.json
+++ b/charts/snyk-broker/values.schema.json
@@ -270,10 +270,12 @@
     "tlsRejectUnauthorized":{
       "type": [
         "string",
-        "boolean"
+        "boolean",
+        "integer"
       ],
       "enum":[
         "",
+        0,
         "0",
         "false",
         false,


### PR DESCRIPTION
### What

- Handle cases where `tlsRejectUnauthorized` is set to `false` (boolean) or `"0"` (string)

### Why

- Previously setting this value to `false` has no effect
- Passing `"0"` via `--set` causes Helm to cast `"0"` as `0`, which has fails input validation
