### PR TITLE
fix: validate certificate format

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,1 @@
+607a5d5d16b365165d8636e526ed92a2ea116719:charts/snyk-broker/tests/broker_deployment_ca_test.yaml:private-key:271

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,1 +1,0 @@
-charts/snyk-broker/tests/broker_deployment_ca_test.yaml:private-key:271

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,1 @@
+charts/snyk-broker/tests/broker_deployment_ca_test.yaml:private-key:271

--- a/charts/snyk-broker/Chart.yaml
+++ b/charts/snyk-broker/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: snyk-broker
-version: 2.7.2
+version: 2.7.3
 description: A Helm chart for Kubernetes
 type: application

--- a/charts/snyk-broker/tests/broker_deployment_ca_test.yaml
+++ b/charts/snyk-broker/tests/broker_deployment_ca_test.yaml
@@ -268,6 +268,6 @@ tests:
 
   - it: rejects a non-PEM certificate
     set:
-      caCertFile: "\n  \n-----BEGIN RSA PRIVATE KEY-----\nCERTIFICATE GOES HERE\n-----END RSA PRIVATE KEY-----\n\n\n"
+      caCertFile: "\n  \n-----BEGIN RSA PRIVATE KEY-----\nCERTIFICATE GOES HERE\n-----END RSA PRIVATE KEY-----\n\n\n" #gitleaks:allow
     asserts:
       - failedTemplate: {}

--- a/charts/snyk-broker/tests/broker_deployment_ca_test.yaml
+++ b/charts/snyk-broker/tests/broker_deployment_ca_test.yaml
@@ -265,3 +265,9 @@ tests:
         documentSelector:
           path: metadata.name
           value: RELEASE-NAME-snyk-broker-cacert-secret
+
+  - it: rejects a non-PEM certificate
+    set:
+      caCertFile: "\n  \n-----BEGIN RSA PRIVATE KEY-----\nCERTIFICATE GOES HERE\n-----END RSA PRIVATE KEY-----\n\n\n"
+    asserts:
+      - failedTemplate: {}

--- a/charts/snyk-broker/values.schema.json
+++ b/charts/snyk-broker/values.schema.json
@@ -262,7 +262,8 @@
       "type": "string"
     },
     "caCertFile": {
-      "type": "string"
+      "type": "string",
+      "pattern": "^$|^\\s*-----BEGIN CERTIFICATE-----(?:.|\\s)*-----END CERTIFICATE-----\\s*$"
     },
     "disableCaCertTrust": {
       "type": "boolean"


### PR DESCRIPTION
### What

- Expect certificates provided as values to have `-----BEGIN CERTIFICATE-----` as header, and `-----END CERTIFICATE-----` as footer

### Why

- We do not expect any private key material, nor do we support certificates in other formats
