### PR TITLE
fix: allow nexus url and base url to share secret, force unique keys

### DIFF
--- a/charts/snyk-broker/Chart.yaml
+++ b/charts/snyk-broker/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: snyk-broker
-version: 2.8.0
+version: 2.8.1
 description: A Helm chart for Kubernetes
 type: application

--- a/charts/snyk-broker/templates/_notes.tpl
+++ b/charts/snyk-broker/templates/_notes.tpl
@@ -7,6 +7,9 @@
 {{- $containerRegistryAgentTemplates := (list "scmToken" )}}
 {{- $templatesPerType := (dict "github-com" $scmTemplates "github-enterprise" $scmTemplates "gitlab" $scmTemplates "bitbucket-server" $scmTemplates "bitbucket-server-bearer-auth" $scmTemplates "azure-repos" $scmTemplates "artifactory" $artifactoryTemplates "nexus" $nexusTemplates "jira" $scmTemplates "jira-bearer-auth" $scmTemplates "container-registry-agent" $containerRegistryAgentTemplates ) }}
 {{- if not .Values.useExternalSecrets -}}
+{{- if not .Values.brokerToken }}
+{{ printf "-> %s:%s <your-broker-token>" (include "snyk-broker.brokerTokenSecretName" . ) (include "snyk-broker.brokerTokenSecretKey" . ) }}
+{{- end }}
 {{- range (get $templatesPerType .Values.scmType ) }}
 {{- $secretObject :=  (first (fromYamlArray (include (printf "snyk-broker.%s" . ) $ ))) }}
 {{- $envName := $secretObject.name }}

--- a/charts/snyk-broker/templates/_scmConfig.tpl
+++ b/charts/snyk-broker/templates/_scmConfig.tpl
@@ -343,7 +343,7 @@ Define artifactory values
 {{- include "snyk-broker.brokerClientPort" . }}
 {{- include "snyk-broker.brokerClientUrl" . }}
 {{- include "snyk-broker.artifactoryUrl" . }}
-{{- if .Values.brokerClientValidationUrl }}
+{{- if or .Values.brokerClientValidationUrl .Values.brokerClientValidationUrlSecret.key .Values.brokerClientValidationUrlSecret.name }}
 {{- include "snyk-broker.brokerClientValidationUrl" . }}
 {{- end }}
 {{- end }}
@@ -354,16 +354,16 @@ Define Nexus 3/2 values
 */}}
 {{- define "snyk-broker.nexus" -}}
 {{- if contains "nexus" .Values.scmType }}
-{{- if and .Values.nexusUrlSecret.name .Values.baseNexusUrlSecret.name -}}
-{{- if eq .Values.nexusUrlSecret.name .Values.baseNexusUrlSecret.name -}}
-{{- fail "Secret names for nexusUrlSecret and baseNexusUrlSecret must be unique" -}}
+{{- if and .Values.nexusUrlSecret.key .Values.baseNexusUrlSecret.key -}}
+{{- if eq .Values.nexusUrlSecret.key .Values.baseNexusUrlSecret.key -}}
+{{- fail "Secret keys for nexusUrlSecret and baseNexusUrlSecret must be unique" -}}
 {{- end }}
 {{- end }}
 {{- include "snyk-broker.brokerToken" . }}
 {{- include "snyk-broker.brokerClientPort" . }}
 {{- include "snyk-broker.baseNexusUrl" . }}
 {{- include "snyk-broker.nexusUrl" . }}
-{{- if .Values.brokerClientValidationUrl }}
+{{- if or .Values.brokerClientValidationUrl .Values.brokerClientValidationUrlSecret.key .Values.brokerClientValidationUrlSecret.name }}
 {{- include "snyk-broker.brokerClientValidationUrl" . }}
 {{- end }}
 {{- end }}

--- a/charts/snyk-broker/tests/broker_deployment_rename_secrets_test.yaml
+++ b/charts/snyk-broker/tests/broker_deployment_rename_secrets_test.yaml
@@ -273,18 +273,18 @@ tests:
           value: artifactory-url-for-validation
         template: secrets.yaml
 
-  - it: Rejects duplicative names for nexus secrets
+  - it: Rejects duplicative keys for nexus secrets
     set:
       scmType: nexus
       nexusUrl: https://user:@nexus.corp.io/repository
       baseNexusUrl: https://user:@nexus.corp.io
       brokerClientValidationUrl: https://nexus.corp.io/service/rest/v1/status/check
-      nexusUrlSecret.name: private-nexus
-      baseNexusUrlSecret.name: private-nexus
+      nexusUrlSecret.key: private-nexus
+      baseNexusUrlSecret.key: private-nexus
     asserts:
       - failedTemplate:
-          errorMessage: Secret names for nexusUrlSecret and baseNexusUrlSecret must be unique
-        template: broker_deployment.yaml
+          errorMessage: Secret keys for nexusUrlSecret and baseNexusUrlSecret must be unique
+    template: broker_deployment.yaml
 
   - it: Sets names for nexus secrets, retaining default keys
     set:
@@ -352,3 +352,46 @@ tests:
             secret:
               secretName: my-ca
         template: broker_deployment.yaml
+
+  - it: handles all required secrets in one kubernetes secret
+    set:
+      scmType: nexus
+      useExternalSecrets: true
+      nexusUrlSecret.name: my-big-broker-secret
+      baseNexusUrlSecret.name: my-big-broker-secret
+      brokerTokenSecret.name: my-big-broker-secret
+      brokerClientValidationUrlSecret.name: my-big-broker-secret
+    template: broker_deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: NEXUS_URL
+            valueFrom:
+              secretKeyRef:
+                name: my-big-broker-secret
+                key:  nexus-nexus-url
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: BROKER_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: my-big-broker-secret
+                key:  nexus-broker-token-key
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: BASE_NEXUS_URL
+            valueFrom:
+              secretKeyRef:
+                name: my-big-broker-secret
+                key:  nexus-base-nexus-url
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: BROKER_CLIENT_VALIDATION_URL
+            valueFrom:
+              secretKeyRef:
+                name: my-big-broker-secret
+                key:  nexus-broker-client-validation-url


### PR DESCRIPTION
### What

- Removes the erroneous enforcement of uniqueness for nexus external secret keys
- Tests secret values may all be sourced from the same k8s secret object