### PR TITLE
fix: correct notes w/ external secrets

### DIFF
--- a/charts/snyk-broker/templates/NOTES.txt
+++ b/charts/snyk-broker/templates/NOTES.txt
@@ -5,7 +5,7 @@ Login to the Snyk UI to start onboarding projects: https://app.snyk.io
 {{ $tenant := regexFind "[a-z]+.snyk.io" .Values.brokerServerUrl }}
 {{ printf "Login to the Snyk UI to start onboarding projects: https://app.%s" $tenant }}
 {{ end }}
-{{- if not  .Values.useExternalSecrets}}
+{{- if .Values.useExternalSecrets }}
 ### Secret Creation Disabled ###
 
 Ensure secrets are present on your cluster in the {{.Release.Namespace}} namespace:


### PR DESCRIPTION
### What

Displays the `external secrets` section of NOTES.txt if `.Values.useExternalSecrets` is `true` instead of `false`