### PR TITLE
fix: missing volumemount for ca cert, tls

### DIFF
--- a/charts/snyk-broker/Chart.yaml
+++ b/charts/snyk-broker/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: snyk-broker
-version: 2.8.1
+version: 2.8.2
 description: A Helm chart for Kubernetes
 type: application

--- a/charts/snyk-broker/templates/NOTES.txt
+++ b/charts/snyk-broker/templates/NOTES.txt
@@ -5,7 +5,7 @@ Login to the Snyk UI to start onboarding projects: https://app.snyk.io
 {{ $tenant := regexFind "[a-z]+.snyk.io" .Values.brokerServerUrl }}
 {{ printf "Login to the Snyk UI to start onboarding projects: https://app.%s" $tenant }}
 {{ end }}
-{{- if not  .Values.useExternalSecrets}}
+{{- if .Values.useExternalSecrets }}
 ### Secret Creation Disabled ###
 
 Ensure secrets are present on your cluster in the {{.Release.Namespace}} namespace:

--- a/charts/snyk-broker/templates/broker_deployment.yaml
+++ b/charts/snyk-broker/templates/broker_deployment.yaml
@@ -87,12 +87,12 @@ spec:
                 mountPath: /home/node/private
                 readOnly: true
               {{- end }}
-              {{- if or (.Values.caCert) (.Values.caCertFile) }}
+              {{- if or (.Values.caCert) (.Values.caCertFile) (and .Values.caCertFileSecret.key .Values.caCertFileSecret.name ) }}
               - name: {{ include "snyk-broker.fullname" . }}-cacert-volume
                 mountPath: /home/node/cacert
                 readOnly: true
               {{- end }}
-              {{- if and (.Values.httpsCert) (.Values.httpsKey) }}
+              {{- if or ( and (.Values.httpsCert) (.Values.httpsKey) )  (and .Values.httpsSecret.key .Values.httpsSecret.name ) }}
               - name: {{ include "snyk-broker.fullname" . }}-tls-secret-volume
                 mountPath: /home/node/tls-cert/
                 readOnly: true

--- a/charts/snyk-broker/templates/broker_deployment.yaml
+++ b/charts/snyk-broker/templates/broker_deployment.yaml
@@ -87,12 +87,12 @@ spec:
                 mountPath: /home/node/private
                 readOnly: true
               {{- end }}
-              {{- if or (.Values.caCert) (.Values.caCertFile) (and .Values.caCertFileSecret.key .Values.caCertFileSecret.name ) }}
+              {{- if or (.Values.caCert) (.Values.caCertFile) ( .Values.caCertFileSecret.name ) }}
               - name: {{ include "snyk-broker.fullname" . }}-cacert-volume
                 mountPath: /home/node/cacert
                 readOnly: true
               {{- end }}
-              {{- if or ( and (.Values.httpsCert) (.Values.httpsKey) )  (and .Values.httpsSecret.key .Values.httpsSecret.name ) }}
+              {{- if or ( and (.Values.httpsCert) (.Values.httpsKey) ) ( .Values.httpsSecret.name ) }}
               - name: {{ include "snyk-broker.fullname" . }}-tls-secret-volume
                 mountPath: /home/node/tls-cert/
                 readOnly: true
@@ -219,7 +219,7 @@ spec:
         configMap:
           name: {{ include "snyk-broker.fullname" . }}-accept-configmap{{if not .Values.disableSuffixes }}-{{ .Release.Name }}{{ end }}
       {{- end }}
-      {{- if or (.Values.caCert) ( or ( and .Values.caCertFileSecret.name .Values.caCertFileSecret.key ) .Values.caCertFile) }}
+      {{- if or .Values.caCert .Values.caCertFileSecret.name .Values.caCertFile }}
       - name: {{ include "snyk-broker.fullname" . }}-cacert-volume
         secret:
           secretName: {{ include "snyk-broker.caCertSecretName" . }}

--- a/charts/snyk-broker/tests/broker_deployment_ca_test.yaml
+++ b/charts/snyk-broker/tests/broker_deployment_ca_test.yaml
@@ -271,3 +271,28 @@ tests:
       caCertFile: "\n  \n-----BEGIN RSA PRIVATE KEY-----\nCERTIFICATE GOES HERE\n-----END RSA PRIVATE KEY-----\n\n\n" #gitleaks:allow
     asserts:
       - failedTemplate: {}
+
+  - it: correctly mounts an external CA secret
+    set:
+      useExternalSecrets: true
+      caCertFileSecret:
+        name: secret-ca-cert
+        key: caCert
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: RELEASE-NAME-snyk-broker-cacert-volume
+            secret:
+              secretName: secret-ca-cert
+        template: broker_deployment.yaml
+      - exists:
+          path: spec.template.spec.containers[0].volumeMounts
+        template: broker_deployment.yaml
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: RELEASE-NAME-snyk-broker-cacert-volume
+            mountPath: /home/node/cacert
+            readOnly: true
+        template: broker_deployment.yaml

--- a/charts/snyk-broker/tests/broker_deployment_ca_test.yaml
+++ b/charts/snyk-broker/tests/broker_deployment_ca_test.yaml
@@ -296,3 +296,28 @@ tests:
             mountPath: /home/node/cacert
             readOnly: true
         template: broker_deployment.yaml
+
+
+  - it: correctly mounts an external CA secret with default key
+    set:
+      useExternalSecrets: true
+      caCertFileSecret:
+        name: my-secret
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: RELEASE-NAME-snyk-broker-cacert-volume
+            secret:
+              secretName: my-secret
+        template: broker_deployment.yaml
+      - exists:
+          path: spec.template.spec.containers[0].volumeMounts
+        template: broker_deployment.yaml
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: RELEASE-NAME-snyk-broker-cacert-volume
+            mountPath: /home/node/cacert
+            readOnly: true
+        template: broker_deployment.yaml

--- a/charts/snyk-broker/tests/broker_deployment_tls_test.yaml
+++ b/charts/snyk-broker/tests/broker_deployment_tls_test.yaml
@@ -1,0 +1,49 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+suite: Broker with TLS
+chart:
+  version: 0.0.0
+templates:
+  - broker_deployment.yaml
+  - ingress.yaml
+values:
+  - ./fixtures/default_values.yaml
+  - ./fixtures/default_values_https_enabled.yaml
+
+tests:
+  - it: sets https correctly
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: HTTPS_CERT
+            value: /home/node/tls-cert/tls.crt
+        template: broker_deployment.yaml
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: HTTPS_KEY
+            value: /home/node/tls-cert/tls.key
+        template: broker_deployment.yaml
+  - it: uses an external tls secret
+    set:
+      useExternalSecrets: true
+      httpsSecret:
+        name: my-ingress-cert
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: RELEASE-NAME-snyk-broker-tls-secret-volume
+            secret:
+              secretName: my-ingress-cert
+        template: broker_deployment.yaml
+      - exists:
+          path: spec.template.spec.containers[0].volumeMounts
+        template: broker_deployment.yaml
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: RELEASE-NAME-snyk-broker-tls-secret-volume
+            mountPath: /home/node/tls-cert/
+            readOnly: true
+        template: broker_deployment.yaml


### PR DESCRIPTION
### What

- Adds missing `volumeMount` for ca-cert and tls secrets if specified externally
