### PR TITLE
fix: add labels to containers

### DIFF
--- a/charts/snyk-broker/Chart.yaml
+++ b/charts/snyk-broker/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: snyk-broker
-version: 2.8.2
+version: 2.8.3
 description: A Helm chart for Kubernetes
 type: application

--- a/charts/snyk-broker/templates/_helpers.tpl
+++ b/charts/snyk-broker/templates/_helpers.tpl
@@ -55,6 +55,13 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
+Pod labels (merge normal labels and selectors)
+*/}}
+{{- define "snyk-broker.podLabels" -}}
+{{- merge (include "snyk-broker.labels" . | fromYaml ) (include "snyk-broker.selectorLabels" . | fromYaml) | toYaml -}}
+{{- end }}
+
+{{/*
 Create the name of the service account to use
 */}}
 {{- define "snyk-broker.serviceAccountName" -}}
@@ -113,7 +120,7 @@ Create the name of the broker service to use
 {{- $serviceLength := len $service -}}
 {{- $releaseNameLength := len .Release.Name -}}
 {{- $truncatedLength := int (sub 63 (add $serviceLength $releaseNameLength)) -}}
-{{- .Values.scmType | trunc $truncatedLength }}{{ $service }}{{ .Release.Name }} 
+{{- .Values.scmType | trunc $truncatedLength }}{{ $service }}{{ .Release.Name }}
 {{- else }}
 {{- .Values.scmType | trunc 47 }}-broker-service
 {{- end -}}

--- a/charts/snyk-broker/templates/broker_deployment.yaml
+++ b/charts/snyk-broker/templates/broker_deployment.yaml
@@ -22,7 +22,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
-        {{- include "snyk-broker.selectorLabels" . | nindent 8 }}
+        {{- include "snyk-broker.podLabels" . | nindent 8 }}
     spec:
       {{- if .Values.extraPodSpecs }}
           {{- toYaml .Values.extraPodSpecs | nindent 6 }}

--- a/charts/snyk-broker/tests/__snapshot__/broker_cra_deployment_disablesuffixes_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/broker_cra_deployment_disablesuffixes_test.yaml.snap
@@ -20,7 +20,9 @@ with CRA:
         metadata:
           labels:
             app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: snyk-broker-RELEASE-NAME
+            helm.sh/chart: snyk-broker-0.0.0
         spec:
           containers:
             - env:

--- a/charts/snyk-broker/tests/__snapshot__/broker_cra_deployment_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/broker_cra_deployment_test.yaml.snap
@@ -20,7 +20,9 @@ with CRA:
         metadata:
           labels:
             app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: snyk-broker-RELEASE-NAME
+            helm.sh/chart: snyk-broker-0.0.0
         spec:
           containers:
             - env:

--- a/charts/snyk-broker/tests/__snapshot__/broker_deployment_apprisk_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/broker_deployment_apprisk_test.yaml.snap
@@ -20,7 +20,9 @@ apprisk enabled:
         metadata:
           labels:
             app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: snyk-broker-RELEASE-NAME
+            helm.sh/chart: snyk-broker-0.0.0
         spec:
           containers:
             - env:

--- a/charts/snyk-broker/tests/__snapshot__/broker_deployment_artifactory_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/broker_deployment_artifactory_test.yaml.snap
@@ -20,7 +20,9 @@ should render artifactoryUrl and brokerClientValidationUrl as secrets:
         metadata:
           labels:
             app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: snyk-broker-RELEASE-NAME
+            helm.sh/chart: snyk-broker-0.0.0
         spec:
           containers:
             - env:

--- a/charts/snyk-broker/tests/__snapshot__/broker_deployment_customaccept_disablesuffixes_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/broker_deployment_customaccept_disablesuffixes_test.yaml.snap
@@ -33,7 +33,9 @@ customaccept values:
         metadata:
           labels:
             app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: snyk-broker
+            helm.sh/chart: snyk-broker-0.0.0
         spec:
           containers:
             - env:

--- a/charts/snyk-broker/tests/__snapshot__/broker_deployment_customaccept_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/broker_deployment_customaccept_test.yaml.snap
@@ -33,7 +33,9 @@ customaccept values:
         metadata:
           labels:
             app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: snyk-broker-RELEASE-NAME
+            helm.sh/chart: snyk-broker-0.0.0
         spec:
           containers:
             - env:

--- a/charts/snyk-broker/tests/__snapshot__/broker_deployment_disablesuffixes_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/broker_deployment_disablesuffixes_test.yaml.snap
@@ -20,7 +20,9 @@ HA mode on:
         metadata:
           labels:
             app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: snyk-broker
+            helm.sh/chart: snyk-broker-0.0.0
         spec:
           containers:
             - env:
@@ -167,7 +169,9 @@ HA mode on with 4 replicas:
         metadata:
           labels:
             app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: snyk-broker
+            helm.sh/chart: snyk-broker-0.0.0
         spec:
           containers:
             - env:
@@ -314,7 +318,9 @@ default values:
         metadata:
           labels:
             app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: snyk-broker
+            helm.sh/chart: snyk-broker-0.0.0
         spec:
           containers:
             - env:
@@ -459,7 +465,9 @@ preflight checks off:
         metadata:
           labels:
             app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: snyk-broker
+            helm.sh/chart: snyk-broker-0.0.0
         spec:
           containers:
             - env:

--- a/charts/snyk-broker/tests/__snapshot__/broker_deployment_ingress_disablesuffixes_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/broker_deployment_ingress_disablesuffixes_test.yaml.snap
@@ -20,7 +20,9 @@ ingress:
         metadata:
           labels:
             app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: snyk-broker
+            helm.sh/chart: snyk-broker-0.0.0
         spec:
           containers:
             - env:

--- a/charts/snyk-broker/tests/__snapshot__/broker_deployment_ingress_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/broker_deployment_ingress_test.yaml.snap
@@ -20,7 +20,9 @@ ingress:
         metadata:
           labels:
             app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: snyk-broker-RELEASE-NAME
+            helm.sh/chart: snyk-broker-0.0.0
         spec:
           containers:
             - env:

--- a/charts/snyk-broker/tests/__snapshot__/broker_deployment_scm_token_pool_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/broker_deployment_scm_token_pool_test.yaml.snap
@@ -20,7 +20,9 @@ github token pool configured:
         metadata:
           labels:
             app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: snyk-broker-RELEASE-NAME
+            helm.sh/chart: snyk-broker-0.0.0
         spec:
           containers:
             - env:
@@ -178,7 +180,9 @@ github token pool configured with enabled useExternalSecretScmTokenPool:
         metadata:
           labels:
             app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: snyk-broker-RELEASE-NAME
+            helm.sh/chart: snyk-broker-0.0.0
         spec:
           containers:
             - env:
@@ -328,7 +332,9 @@ gitlab token pool configured:
         metadata:
           labels:
             app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: snyk-broker-RELEASE-NAME
+            helm.sh/chart: snyk-broker-0.0.0
         spec:
           containers:
             - env:

--- a/charts/snyk-broker/tests/__snapshot__/broker_deployment_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/broker_deployment_test.yaml.snap
@@ -20,7 +20,9 @@ HA mode on:
         metadata:
           labels:
             app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: snyk-broker-RELEASE-NAME
+            helm.sh/chart: snyk-broker-0.0.0
         spec:
           containers:
             - env:
@@ -167,7 +169,9 @@ HA mode on with 4 replicas:
         metadata:
           labels:
             app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: snyk-broker-RELEASE-NAME
+            helm.sh/chart: snyk-broker-0.0.0
         spec:
           containers:
             - env:
@@ -314,7 +318,9 @@ HTTPS enabled:
         metadata:
           labels:
             app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: snyk-broker-RELEASE-NAME
+            helm.sh/chart: snyk-broker-0.0.0
         spec:
           containers:
             - env:
@@ -478,7 +484,9 @@ default values:
         metadata:
           labels:
             app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: snyk-broker-RELEASE-NAME
+            helm.sh/chart: snyk-broker-0.0.0
         spec:
           containers:
             - env:
@@ -623,7 +631,9 @@ preflight checks off:
         metadata:
           labels:
             app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: snyk-broker-RELEASE-NAME
+            helm.sh/chart: snyk-broker-0.0.0
         spec:
           containers:
             - env:

--- a/charts/snyk-broker/tests/__snapshot__/cra_deployment_digitalocean_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/cra_deployment_digitalocean_test.yaml.snap
@@ -20,7 +20,9 @@ default values:
         metadata:
           labels:
             app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: snyk-broker-RELEASE-NAME
+            helm.sh/chart: snyk-broker-0.0.0
         spec:
           containers:
             - env:

--- a/charts/snyk-broker/tests/__snapshot__/cra_deployment_disablesuffixes_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/cra_deployment_disablesuffixes_test.yaml.snap
@@ -20,7 +20,9 @@ default values:
         metadata:
           labels:
             app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: snyk-broker
+            helm.sh/chart: snyk-broker-0.0.0
         spec:
           containers:
             - env:

--- a/charts/snyk-broker/tests/__snapshot__/cra_deployment_harbor_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/cra_deployment_harbor_test.yaml.snap
@@ -20,7 +20,9 @@ default values:
         metadata:
           labels:
             app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: snyk-broker-RELEASE-NAME
+            helm.sh/chart: snyk-broker-0.0.0
         spec:
           containers:
             - env:

--- a/charts/snyk-broker/tests/__snapshot__/cra_deployment_test.yaml.snap
+++ b/charts/snyk-broker/tests/__snapshot__/cra_deployment_test.yaml.snap
@@ -20,7 +20,9 @@ default values:
         metadata:
           labels:
             app.kubernetes.io/instance: RELEASE-NAME
+            app.kubernetes.io/managed-by: Helm
             app.kubernetes.io/name: snyk-broker-RELEASE-NAME
+            helm.sh/chart: snyk-broker-0.0.0
         spec:
           containers:
             - env:

--- a/charts/snyk-broker/tests/broker_deployment_labels_test.yaml
+++ b/charts/snyk-broker/tests/broker_deployment_labels_test.yaml
@@ -10,8 +10,6 @@ values:
 
 tests:
   - it: handles duplicative labels and adds new labels
-    values:
-      - ./fixtures/default_values.yaml
     set:
       labels:
         app.kubernetes.io/name: "my duplicated label"
@@ -25,3 +23,29 @@ tests:
             app.kubernetes.io/name: snyk-broker-RELEASE-NAME
             helm.sh/chart: snyk-broker-0.0.0
             test: node1
+  - it: sets a label
+    set:
+      labels:
+        costCenter: prodsec
+    asserts:
+      - equal:
+          path: metadata.labels.costCenter
+          value: prodsec
+  - it: sets a label on the broker pod
+    set:
+      labels:
+        costCenter: prodsec
+    asserts:
+      - equal:
+          path: spec.template.metadata.labels.costCenter
+          value: prodsec
+    template: broker_deployment.yaml
+  - it: does not override a default label on the broker pod
+    set:
+      labels:
+        app.kubernetes.io/name: fake
+    asserts:
+      - equal:
+          path: spec.template.metadata.labels["app.kubernetes.io/name"]
+          value: snyk-broker-RELEASE-NAME
+    template: broker_deployment.yaml


### PR DESCRIPTION
### What

- Add any labels to broker pods

### Why

- Previously labels were applied at the ReplicaSet level only
