### PR TITLE
fix: Update exec plugin config to use an array of objects

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -13,7 +13,10 @@
       {
         "prepareCmd": "helm package --version ${nextRelease.version} .",
         "execCwd": "charts/snyk-broker"
-      },
+      }
+    ],
+    [
+      "@semantic-release/exec",
       {
         "publishCmd": "cr index -r snyk-broker-helm -o snyk --packages-with-index --index-path . --package-path charts/snyk-broker -t $GH_TOKEN --push"
       }


### PR DESCRIPTION
This PR attempts to resolve the semantic release error complaining that "the option must be an array of plugin definitions"