### PR TITLE
fix: order release operation in semantic-release

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -16,12 +16,6 @@
       }
     ],
     [
-      "@semantic-release/exec",
-      {
-        "publishCmd": "cr index -r snyk-broker-helm -o snyk --packages-with-index --index-path . --package-path charts/snyk-broker -t $GH_TOKEN --push"
-      }
-    ],
-    [
       "@semantic-release/github",
       {
         "assets": [
@@ -31,6 +25,12 @@
         ],
         "successCommentCondition": false,
         "failCommentCondition": false
+      }
+    ],
+    [
+      "@semantic-release/exec",
+      {
+        "publishCmd": "cr index -r snyk-broker-helm -o snyk --packages-with-index --index-path . --package-path charts/snyk-broker -t $GH_TOKEN --push"
       }
     ]
   ]


### PR DESCRIPTION
This PR fixes the issue with missing GH release before executing helm chart release command (cr index ...).