### PR TITLE
fix: bump chart-releaser to v1.7.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ commands:
     parameters:
       cr-version:
         type: string
-        default: "1.6.1"
+        default: "1.7.0"
     steps:
       - restore_cache:
           key: chart-releaser-<<parameters.cr-version>>


### PR DESCRIPTION
This PR bumps chart-releaser version to v1.7.0.

We use fix prefix to trigger semantic-release to generate a new fix version so index.yaml is synced.