### PR TITLE
fix: Fix semantic release repository URL

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -4,7 +4,7 @@
       "name": "main"
     }
   ],
-  "repositoryUrl": "git@github.com:snyk/snyk-broker-helm.git",
+  "repositoryUrl": "https://github.com:snyk/snyk-broker-helm",
   "tagFormat": "snyk-broker-${version}",
   "plugins": [
     "@semantic-release/commit-analyzer",


### PR DESCRIPTION
Semantic release has a bug that fails if the target repo uses SSH and not HTTPS
https://github.com/helm/chart-releaser/issues/124