### PR TITLE
fix(chart/releaser): use https instead of git for origin

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -30,6 +30,7 @@
     [
       "@semantic-release/exec",
       {
+        "prepareCmd": "git remote set-url origin https://github.com/snyk/snyk-broker-helm.git",
         "publishCmd": "cr index -r snyk-broker-helm -o snyk --packages-with-index --index-path . --package-path charts/snyk-broker -t $GH_TOKEN --push"
       }
     ]


### PR DESCRIPTION
This PR fixes the issue with failing `cr index` command => chart-releaser works *only* with HTTPS.

More context: https://github.com/helm/chart-releaser/issues/124#issuecomment-852861417