### PR TITLE
Fix/openshift support

### DIFF
--- a/charts/snyk-broker/templates/_helpers.tpl
+++ b/charts/snyk-broker/templates/_helpers.tpl
@@ -191,17 +191,8 @@ Values are taken from .Values.securityContext.
 When .Values.openshift is true, the runAsUser field is omitted.
 */}}
 {{- define "snyk-broker.securityContext" -}}
-capabilities:
-  {{- if .Values.securityContext.capabilities.drop }}
-  drop:
-    {{- range .Values.securityContext.capabilities.drop }}
-    - {{ . }}
-    {{- end }}
-  {{- end }}
-readOnlyRootFilesystem: {{ .Values.securityContext.readOnlyRootFilesystem | default true }}
-allowPrivilegeEscalation: {{ .Values.securityContext.allowPrivilegeEscalation | default false }}
-runAsNonRoot: {{ .Values.securityContext.runAsNonRoot | default true }}
-{{- if not .Values.openshift }}
-runAsUser: {{ .Values.securityContext.runAsUser }}
-{{- end }}
+{{- $root := . -}}
+{{- $csc := $root.Values.securityContext | default dict -}}
+{{- $sc := ternary (omit $csc "runAsUser" "runAsGroup") $csc $root.Values.openshift -}}
+{{ toYaml $sc | nindent 2 }}
 {{- end }}

--- a/charts/snyk-broker/templates/_helpers.tpl
+++ b/charts/snyk-broker/templates/_helpers.tpl
@@ -202,6 +202,6 @@ readOnlyRootFilesystem: {{ .Values.securityContext.readOnlyRootFilesystem | defa
 allowPrivilegeEscalation: {{ .Values.securityContext.allowPrivilegeEscalation | default false }}
 runAsNonRoot: {{ .Values.securityContext.runAsNonRoot | default true }}
 {{- if not .Values.openshift }}
-runAsUser: {{ .Values.securityContext.runAsUser | default 1000 }}
+runAsUser: {{ .Values.securityContext.runAsUser }}
 {{- end }}
 {{- end }}

--- a/charts/snyk-broker/templates/_helpers.tpl
+++ b/charts/snyk-broker/templates/_helpers.tpl
@@ -185,3 +185,23 @@ Validate against RFC 1123
 {{- end }}
 {{- $sanitisedProxyUrls |  trimPrefix "," -}}
 {{- end }}
+
+{{/*
+Values are taken from .Values.securityContext.
+When .Values.openshift is true, the runAsUser field is omitted.
+*/}}
+{{- define "snyk-broker.securityContext" -}}
+capabilities:
+  {{- if .Values.securityContext.capabilities.drop }}
+  drop:
+    {{- range .Values.securityContext.capabilities.drop }}
+    - {{ . }}
+    {{- end }}
+  {{- end }}
+readOnlyRootFilesystem: {{ .Values.securityContext.readOnlyRootFilesystem | default true }}
+allowPrivilegeEscalation: {{ .Values.securityContext.allowPrivilegeEscalation | default false }}
+runAsNonRoot: {{ .Values.securityContext.runAsNonRoot | default true }}
+{{- if not .Values.openshift }}
+runAsUser: {{ .Values.securityContext.runAsUser | default 1000 }}
+{{- end }}
+{{- end }}

--- a/charts/snyk-broker/templates/broker_deployment.yaml
+++ b/charts/snyk-broker/templates/broker_deployment.yaml
@@ -44,7 +44,7 @@ spec:
               cpu: {{ .Values.brokerResources.requests.cpu }}
               memory: {{ .Values.brokerResources.requests.memory}}
           securityContext:
-            {{- toYaml .Values.securityContext | nindent 12 }}
+            {{ include "snyk-broker.securityContext" . | nindent 12 }}
           {{- if .Values.image.tag }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}-{{ .Values.scmType }}"
           {{- else }}

--- a/charts/snyk-broker/tests/broker_deployment_openshift_securityContext_test.yaml
+++ b/charts/snyk-broker/tests/broker_deployment_openshift_securityContext_test.yaml
@@ -1,0 +1,37 @@
+suite: test openshift broker deployment securityContext
+chart:
+  version: 0.0.0
+templates:
+  - broker_deployment.yaml
+
+tests:
+  - it: "should include runAsUser when openshift is false"
+    set:
+      securityContext:
+        capabilities:
+          drop:
+            - ALL
+        readOnlyRootFilesystem: true
+        allowPrivilegeEscalation: false
+        runAsNonRoot: true
+        runAsUser: 1000
+      openshift: false
+    asserts:
+      - equal:
+          path: "spec.template.spec.containers[0].securityContext.runAsUser"
+          value: 1000
+
+  - it: "should omit runAsUser when openshift is true"
+    set:
+      securityContext:
+        capabilities:
+          drop:
+            - ALL
+        readOnlyRootFilesystem: true
+        allowPrivilegeEscalation: false
+        runAsNonRoot: true
+        runAsUser: 1000
+      openshift: true
+    asserts:
+      - notExists:
+          path: "spec.template.spec.containers[0].securityContext.runAsUser"

--- a/charts/snyk-broker/values.yaml
+++ b/charts/snyk-broker/values.yaml
@@ -527,3 +527,7 @@ extraPodSpecs:
 
 extraPodSpecsCr:
   # As above, for Container Registry Agent
+
+##### Openshift Specific Values #####
+# This is a boolean value that indicates whether the deployment is running on OpenShift or not. Default is set to false to disable security context adaptations for OpenShift.
+openshift: false


### PR DESCRIPTION
What:
- Adds helm helper function that builds the security context from values.yaml, conditionally omitting the runAsUser field when deploying on OpenShift to avoid SCC restrictions. 
- Helm unittests have been added to verify that the security context is correctly configured for both OpenShift and non-OpenShift environments.