### PR TITLE
chore: update codeowners [ACC-2603]

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
-* @snyk/access
+* @snyk/access @snyk/platformeng_access
 
 charts/snyk-broker/templates/cra_deployment.yaml @snyk/infrasec_container
 charts/snyk-broker/tests/broker_cra_deployment_test.yaml @snyk/infrasec_container


### PR DESCRIPTION
This PR updates codeowners [ACC-2603].

Used instead of #170 to get rid of CLA pr check.

[ACC-2603]: https://snyksec.atlassian.net/browse/ACC-2603?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ