### PR TITLE
fix: use HTTPS scheme for probes when TLS certificates are configured

### DIFF
--- a/charts/snyk-broker/templates/broker_deployment.yaml
+++ b/charts/snyk-broker/templates/broker_deployment.yaml
@@ -59,7 +59,7 @@ spec:
             httpGet:
               port: {{ .Values.deployment.container.containerPort }}
               path: {{ .Values.brokerLivenessProbe.path }}
-              {{- if or ( and (.Values.httpsCert) (.Values.httpsKey) ) ( .Values.enableBrokerLocalWebserverOverHttps ) }}
+              {{- if or ( and (.Values.httpsCert) (.Values.httpsKey) ) ( .Values.httpsSecret.name ) }}
               scheme: HTTPS
               {{- else }}
               scheme: HTTP
@@ -71,7 +71,7 @@ spec:
             httpGet:
               port: {{ .Values.deployment.container.containerPort }}
               path: {{ .Values.brokerReadinessProbe.path }}
-              {{- if or ( and (.Values.httpsCert) (.Values.httpsKey) ) ( .Values.enableBrokerLocalWebserverOverHttps ) }}
+              {{- if or ( and (.Values.httpsCert) (.Values.httpsKey) ) ( .Values.httpsSecret.name ) }}
               scheme: HTTPS
               {{- else }}
               scheme: HTTP

--- a/charts/snyk-broker/values.yaml
+++ b/charts/snyk-broker/values.yaml
@@ -259,8 +259,9 @@ logEnableBody: "false"
 
 ##### Enable HTTPS #####
 
-# To enable broker client to run a HTTPS server enable enableBrokerLocalWebserverOverHttps flag and also provide location of HTTPS_CERT and HTTPS_KEY
-enableBrokerLocalWebserverOverHttps: false
+# When HTTPS certificates are provided, the broker serves all endpoints over HTTPS
+# including the healthcheck endpoint. Probes will automatically use HTTPS scheme.
+# Note: enableBrokerLocalWebserverOverHttps is deprecated and no longer used
 
 # Location of mounted cert
 httpsCert: ""


### PR DESCRIPTION
## Description
When configuring TLS certificates for the Snyk broker, pod restart loops due to failing health probes. The broker serves HTTPS on all endpoints when certificates are configured, but the Helm chart's probe logic incorrectly determines when to use HTTPS scheme.

## RCA

After updating TLS certificates in our production Kubernetes deployment, we encountered continuous pod restarts with these errors:
- Initial: `connection refused` on port 443
- After changing to port 8000: `EOF` errors on healthcheck probes

### Investigation & Evidence

1. **Confirmed broker was running successfully:**
```json
{"level":30,"msg":"Successfully established a websocket connection to the broker server.","time":"2025-09-17T17:48:32.899Z"}
```

2. **Tested healthcheck endpoint directly from within cluster:**
```bash
# HTTP request - FAILED
$ curl http://x.x.x.x:8000/healthcheck
curl: (7) Failed to connect to x.x.x.x port 8000 after 0 ms: Could not connect to server

# HTTPS request - SUCCESS
$ curl -k https://x.x.x.x:8000/healthcheck
[{"ok":true,"websocketConnectionOpen":true,"brokerServerUrl":"https://broker.snyk.io/?connection_role=primary"...}]
```

3. **Identified the issue:**
The Helm chart checks for `enableBrokerLocalWebserverOverHttps` to determine probe scheme, but:
- This value doesn't correspond to any Snyk broker environment variable or functionality
- The broker automatically serves `HTTPS` when `HTTPS_CERT` and `HTTPS_KEY` environment variables are present
- Testing confirmed the broker ignores any `enableBrokerLocalWebserverOverHttps` setting
- The actual trigger for `HTTPS` mode is solely the presence of certificate files

## Solution
Update probe scheme logic to check only for actual certificate configuration:
- `httpsCert` and `httpsKey` values
- `httpsSecret.name` (for external TLS secrets)

Remove dependency on non-existent `enableBrokerLocalWebserverOverHttps` flag.

## Testing

### Before Fix
```yaml
# With enableBrokerLocalWebserverOverHttps and wrong probe scheme
Events:
  Warning  Unhealthy  Readiness probe failed: Get "http://x.x.x.x:8000/healthcheck": EOF
  Warning  Unhealthy  Liveness probe failed: Get "http://x.x.x.x:8000/healthcheck": EOF
  Warning  BackOff    Back-off restarting failed container
```

### After Fix
```yaml
# With correct HTTPS probe scheme when certificates present
livenessProbe:
  scheme: HTTPS  # Correctly set when certs configured
readinessProbe:
  scheme: HTTPS  # Correctly set when certs configured

# Result: Pod running successfully, probes passing
```

### Validation
- Tested with `httpsCert`/`httpsKey` values: Probes use HTTPS
- Tested with `httpsSecret.name`: Probes use HTTPS  
- Tested without certificates: Probes use HTTP
- Confirmed backward compatibility: Old configs still work

## Impact
- Fixes pod restart loops when using TLS certificates with Probes
- Prevents hours of debugging for users configuring HTTPS
- Correctly aligns Helm chart behavior with actual broker functionality

## Documentation References

### Official Snyk Broker Documentation
- [Advanced configuration for HTTPS](https://docs.snyk.io/enterprise-setup/snyk-broker/install-and-configure-snyk-broker/advanced-configuration-for-snyk-broker-docker-installation/https-for-broker-client-with-docker)
- [Troubleshooting Broker](https://docs.snyk.io/enterprise-setup/snyk-broker/troubleshooting-broker)

Resolves issues where users experience probe failures after configuring TLS certificates.