### PR TITLE
Fix/disable node network autoselection option

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,6 +73,7 @@ workflows:
           name: Scan repository for secrets
           context:
             - snyk-bot-slack
+          trusted-branch: main
           channel: broker-alerts
       - commitlint/lint:
           name: Conventional Commit Lint

--- a/charts/snyk-broker/templates/broker_deployment.yaml
+++ b/charts/snyk-broker/templates/broker_deployment.yaml
@@ -214,6 +214,11 @@ spec:
             - name: BROKER_HA_MODE_ENABLED
               value: "true"
         {{- end}}
+        {{- if .Values.disableNetworkAutoSelection }}
+         # Disable Node.js automatic network family selection to prevent ETIMEDOUT in dual-stack environments
+            - name: NODE_OPTIONS
+              value: "--no-network-family-autoselection"
+        {{- end}}
         {{- range .Values.env }}
          # custom env var in override.yaml
             - name: {{ .name }}

--- a/charts/snyk-broker/tests/broker_deployment_network_autoselection_test.yaml
+++ b/charts/snyk-broker/tests/broker_deployment_network_autoselection_test.yaml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+suite: test broker network auto selection configuration
+chart:
+  version: 0.0.0
+templates:
+  - broker_deployment.yaml
+values:
+  - ./fixtures/default_values.yaml
+
+tests:
+  - it: does not set NODE_OPTIONS when disableNetworkAutoSelection is false (default)
+    set:
+      disableNetworkAutoSelection: false
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: NODE_OPTIONS
+          any: true
+  - it: sets NODE_OPTIONS when disableNetworkAutoSelection is true
+    set:
+      disableNetworkAutoSelection: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: NODE_OPTIONS
+            value: "--no-network-family-autoselection"

--- a/charts/snyk-broker/values.schema.json
+++ b/charts/snyk-broker/values.schema.json
@@ -296,6 +296,11 @@
         "true"
       ]
     },
+    "disableNetworkAutoSelection": {
+      "type": "boolean",
+      "default": false,
+      "description": "Disable Node.js automatic IPv4/IPv6 network family selection (autoSelectFamily). Enable this if experiencing ETIMEDOUT errors in dual-stack environments."
+    },
     "enableBrokerLocalWebserverOverHttps": {
       "type": "boolean"
     },

--- a/charts/snyk-broker/values.yaml
+++ b/charts/snyk-broker/values.yaml
@@ -257,6 +257,14 @@ logLevel: "info"
 # Add additional logging by setting to true
 logEnableBody: "false"
 
+##### Network Configuration #####
+
+# Disable Node.js automatic IPv4/IPv6 network family selection (autoSelectFamily).
+# When enabled, sets NODE_OPTIONS="--no-network-family-autoselection"
+# Enable this if experiencing ETIMEDOUT errors in environments
+# See: https://github.com/nodejs/node/issues/54359
+disableNetworkAutoSelection: false
+
 ##### Enable HTTPS #####
 
 # To enable broker client to run a HTTPS server enable enableBrokerLocalWebserverOverHttps flag and also provide location of HTTPS_CERT and HTTPS_KEY


### PR DESCRIPTION
What: 

-  Add helm chart option to disable Node.js automatic IPv4/IPv6 network family selection (autoSelectFamily). When enabled, sets NODE_OPTIONS with `--no-network-family-autoselection.`
- Ref: https://snyk.slack.com/archives/C0ALK1Z8480/p1773680719670229