### PR TITLE
fix: pin prodsec-orb to major version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  prodsec: snyk/prodsec-orb@1.0
+  prodsec: snyk/prodsec-orb@1
   helm: circleci/helm@3
   commitlint: conventional-changelog/commitlint@1.0
 


### PR DESCRIPTION
This PR pins `snyk/prodsec-orb` to major version 1.

p.s.: commit is `fix` to trigger a new release.