### PR TITLE
fix: set dns-result-order if disableNetworkAutoSelection specified

### DIFF
--- a/charts/snyk-broker/templates/broker_deployment.yaml
+++ b/charts/snyk-broker/templates/broker_deployment.yaml
@@ -217,7 +217,7 @@ spec:
         {{- if .Values.disableNetworkAutoSelection }}
          # Disable Node.js automatic network family selection to prevent ETIMEDOUT in dual-stack environments
             - name: NODE_OPTIONS
-              value: "--no-network-family-autoselection"
+              value: "--no-network-family-autoselection --dns-result-order=ipv4first"
         {{- end}}
         {{- range .Values.env }}
          # custom env var in override.yaml

--- a/charts/snyk-broker/tests/broker_deployment_network_autoselection_test.yaml
+++ b/charts/snyk-broker/tests/broker_deployment_network_autoselection_test.yaml
@@ -25,4 +25,4 @@ tests:
           path: spec.template.spec.containers[0].env
           content:
             name: NODE_OPTIONS
-            value: "--no-network-family-autoselection"
+            value: "--no-network-family-autoselection --dns-result-order=ipv4first"


### PR DESCRIPTION
This PR adds an additional parameter to NODE_OPTIONS `--dns-result-order` if **disableNetworkAutoSelection** is specified. This will ensure that broker client won’t try to connect to IPv6 addresses if an IPv4 address is available.