### PR TITLE
feat: align happy eyeball fix via broker configuration

### DIFF
--- a/charts/snyk-broker/templates/broker_deployment.yaml
+++ b/charts/snyk-broker/templates/broker_deployment.yaml
@@ -214,10 +214,14 @@ spec:
             - name: BROKER_HA_MODE_ENABLED
               value: "true"
         {{- end}}
-        {{- if .Values.disableNetworkAutoSelection }}
+        {{- if and .Values.disableNetworkAutoSelection .Values.ipv6ConnectivityCheck.enabled }}
          # Disable Node.js automatic network family selection to prevent ETIMEDOUT in dual-stack environments
             - name: NODE_OPTIONS
               value: "--no-network-family-autoselection --dns-result-order=ipv4first"
+        {{- end}}
+        {{- if or (not .Values.ipv6ConnectivityCheck.enabled) .Values.disableNetworkAutoSelection }}
+            - name: IPV6_CONNECTIVITY_CHECK_ENABLED
+              value: "false"
         {{- end}}
         {{- range .Values.env }}
          # custom env var in override.yaml

--- a/charts/snyk-broker/tests/broker_deployment_network_autoselection_test.yaml
+++ b/charts/snyk-broker/tests/broker_deployment_network_autoselection_test.yaml
@@ -17,7 +17,15 @@ tests:
           content:
             name: NODE_OPTIONS
           any: true
-  - it: sets NODE_OPTIONS when disableNetworkAutoSelection is true
+  - it: does not set IPV6_CONNECTIVITY_CHECK_ENABLED by default
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: IPV6_CONNECTIVITY_CHECK_ENABLED
+          any: true
+
+  - it: sets NODE_OPTIONS and IPV6_CONNECTIVITY_CHECK_ENABLED=false when disableNetworkAutoSelection is true
     set:
       disableNetworkAutoSelection: true
     asserts:
@@ -26,3 +34,41 @@ tests:
           content:
             name: NODE_OPTIONS
             value: "--no-network-family-autoselection --dns-result-order=ipv4first"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: IPV6_CONNECTIVITY_CHECK_ENABLED
+            value: "false"
+
+  - it: sets IPV6_CONNECTIVITY_CHECK_ENABLED=false and no NODE_OPTIONS when ipv6ConnectivityCheck.enabled is false
+    set:
+      ipv6ConnectivityCheck:
+        enabled: false
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: IPV6_CONNECTIVITY_CHECK_ENABLED
+            value: "false"
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: NODE_OPTIONS
+          any: true
+
+  - it: ipv6ConnectivityCheck.enabled false takes precedence over disableNetworkAutoSelection, no NODE_OPTIONS rendered
+    set:
+      disableNetworkAutoSelection: true
+      ipv6ConnectivityCheck:
+        enabled: false
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: IPV6_CONNECTIVITY_CHECK_ENABLED
+            value: "false"
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: NODE_OPTIONS
+          any: true

--- a/charts/snyk-broker/values.yaml
+++ b/charts/snyk-broker/values.yaml
@@ -259,11 +259,18 @@ logEnableBody: "false"
 
 ##### Network Configuration #####
 
+
+# Deprecated: use ipv6ConnectivityCheck.enabled: false instead. When true, forces ipv4-first
+# via NODE_OPTIONS and also disables the broker's IPv6 connectivity check.
 # Disable Node.js automatic IPv4/IPv6 network family selection (autoSelectFamily).
 # When enabled, sets NODE_OPTIONS="--no-network-family-autoselection"
 # Enable this if experiencing ETIMEDOUT errors in environments
 # See: https://github.com/nodejs/node/issues/54359
 disableNetworkAutoSelection: false
+
+# Set to false to disable the broker's built-in IPv6 connectivity check (happy-eyeballs fix).
+ipv6ConnectivityCheck:
+  enabled: true
 
 ##### Enable HTTPS #####
 


### PR DESCRIPTION
This PR adds `ipv6ConnectivityCheck.enabled` to control broker's IPv6 connectivity check. See [corresponding PR](https://github.com/snyk/broker/pull/1110). 

The broker now ships with `IPV6_CONNECTIVITY_CHECK_ENABLED=true` by default, which handles the happy-eyeballs fix natively. This PR exposes that flag via a new `ipv6ConnectivityCheck.enabled` value (default: true) and aligns it with the existing `disableNetworkAutoSelection` parameter.

`disableNetworkAutoSelection` remains backward compatible for existing configurations that haven't set `ipv6ConnectivityCheck.enabled`. When `ipv6ConnectivityCheck.enabled: false` is explicitly set, it takes full precedence - `IPV6_CONNECTIVITY_CHECK_ENABLED=false` achieves the same result as NODE_OPTIONS without the Node-level flag.


| `ipv6ConnectivityCheck` | `disableNetworkAutoSelection` | `NODE_OPTIONS` | `IPV6_CONNECTIVITY_CHECK_ENABLED` |
|---|---|---|---|
| `true` (default) | `false` (default) | — | — |
| `true` (default) | `true` (legacy) | set | `false` |
| `false` | `false` | — | `false` |
| `false` | `true` | — | `false` |